### PR TITLE
Updates to mock files. Fix parsequery usage. Fix odkData to use Java dataTableModel

### DIFF
--- a/app/system/js/mock/odkDataIf.js
+++ b/app/system/js/mock/odkDataIf.js
@@ -476,11 +476,15 @@ var odkDataIf = {
 						}
 					}
                     content.data = resultRows;
+					content.metadata = {};
                     content.metadata.tableId = tableDef.tableId;
                     content.metadata.schemaETag = tableDef.schemaETag;
                     content.metadata.lastDataETag = tableDef.lastDataETag;
                     content.metadata.lastSyncTime = tableDef.lastSyncTime;
                     content.metadata.elementKeyMap = elementNameMap;
+					// TODO: determine the correct value for this
+					content.metadata.canCreateRow = true;
+					content.metadata.dataTableModel = tableDef.dataTableModel;
                     content.metadata.orderedColumns = tableDef.orderedColumns;
                     content.metadata.keyValueStoreList = tableDef.keyValueStoreList;
                 });
@@ -530,6 +534,7 @@ var odkDataIf = {
 
         that._getTableDef($.extend({}, ctxt, {
             success: function(tableDef) {
+				// TODO: row filtering
                 var sql = 'SELECT * FROM "' + tableId + '"';
                 if ( whereClause !== null && whereClause !== undefined ) {
                     sql = sql + " WHERE " + whereClause;
@@ -561,6 +566,7 @@ var odkDataIf = {
     arbitraryQuery: function(tableId, sqlCommand, sqlBindParamsJSON, limit, offset, _callbackId) {
         var that = this;
 
+		// TODO: row filtering
 		var sqlBindParams = (sqlBindParamsJSON === null || sqlBindParamsJSON === undefined) ?
 			[] : JSON.parse(sqlBindParamsJSON);
 
@@ -591,6 +597,7 @@ var odkDataIf = {
 
         that._getTableDef($.extend({}, ctxt, {
             success: function(tableDef) {
+				// TODO: row filtering
                 var sqlStatement = {
                         stmt : 'select * from "' + tableId + '" where _id=?',
                         bind : [ rowId ]
@@ -603,6 +610,7 @@ var odkDataIf = {
     _getMostRecentRow: function( ctxt, tableDef, rowId ) {
         var that = this;
 
+		// TODO: row filtering
         var sqlStatement =  {
             stmt : 'select * from "' + tableDef.tableId + '" as T where _id=? and ' +
                     'T._savepoint_timestamp=(select max(V._savepoint_timestamp) from "' +

--- a/app/system/js/odkCommon.js
+++ b/app/system/js/odkCommon.js
@@ -1377,6 +1377,15 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                 return "OK";
             }
         },
+		closeWindow: function( resultCode, jsonResult ) {
+			// TODO: return resultCode and result when there is a parent window
+			// stub just closes window and doesn't return value.
+		    if ( window.parent === window ) { 
+                window.close(); 
+            } else { 
+                window.parent.closeAndPopPage(); 
+            } 
+		},
         /**
          * Return the first queued action without removing it.
          */

--- a/app/system/js/odkData.js
+++ b/app/system/js/odkData.js
@@ -80,7 +80,6 @@ window.odkData = {
 				JSON.stringify(sqlBindParams);
         that.getOdkDataIf().query(tableId, whereClause, sqlBindParamsJSON, groupBy, 
             having, orderByElementKey, orderByDirection, limit, offset, includeKVS, req._callbackId);
-//             having, orderByElementKey, orderByDirection, limit, offset, false, req._callbackId);
     },
 
     arbitraryQuery: function(tableId, sqlCommand, sqlBindParams, limit, offset, successCallbackFn, failureCallbackFn) {

--- a/app/system/survey/js/database.js
+++ b/app/system/survey/js/database.js
@@ -23,6 +23,11 @@ return {
         var that = this;
 
         if ( table_id === 'framework' ) {
+			// TODO: should go away in the future??
+			// This should REMAIN the only place that 
+			//   formDef.specification.dataTableModel
+			//   formDef.specification.properties
+			// are directly referenced. 
             var tlo = {data: {},      // dataTable instance data values
                 instanceMetadata: {}, // dataTable instance Metadata: (_savepoint_timestamp, _savepoint_creator, _savepoint_type, _form_id, _locale)
                 metadata: {},         // see definition in opendatakit.js
@@ -62,13 +67,14 @@ return {
                     var tlo = {data: {},      // dataTable instance data values
                         instanceMetadata: {}, // dataTable instance Metadata: (_savepoint_timestamp, _savepoint_creator, _savepoint_type, _form_id, _locale)
                         metadata: {},         // see definition in opendatakit.js
-                        dataTableModel: formDef.specification.dataTableModel, // inverted and extended formDef.model for representing data store
+                        dataTableModel:{}, // inverted and extended formDef.model for representing data store
                         formDef: formDef,
                         formPath: formPath,
                         instanceId: null,
                         table_id: table_id
                         };
-                    tlo.metadata = reqData.metadata;
+                    tlo.metadata = reqData.getMetadata();
+					tlo.dataTableModel = reqData.getMetadata().dataTableModel
                     ctxt.success(tlo);
                 },
                 function (errorMsg) {

--- a/app/system/survey/js/odkSurveyStateManagement.js
+++ b/app/system/survey/js/odkSurveyStateManagement.js
@@ -14,12 +14,30 @@ It will be replaced by one injected by Android Java code.
 'use strict';
 /* global odkCommon */
 window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
+	_nonEmbeddedState: {},
     showAlerts: false,
-    refId: null,
     enforceRefIdMatch: true,
     clearAuxillaryHash: function() {
         // this only makes sense for screen-rotation recovery actions.
     },
+	_getSurveyStateMgmt: function() {
+		// if ( window.parent === window ) {
+			return this._nonEmbeddedState;
+		// } else {
+		//	return window.parent.getSurveyStateMgmt();
+		// }
+	},
+	_setRefId: function(refId) {
+		var surveyStateMgmt = this._getSurveyStateMgmt();
+		surveyStateMgmt.refId = refId;
+	},
+	_getRefId: function() {
+		var surveyStateMgmt = this._getSurveyStateMgmt();
+		if ( !('refId' in surveyStateMgmt) ) {
+			surveyStateMgmt.refId = null;
+		}
+		return surveyStateMgmt.refId;
+	},
     /**
      * The odkSurveyStateManagement now remembers an entire history of refId values.
      *
@@ -28,20 +46,23 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
      *   instanceId
      *   sectionStateScreenHistory
      */
-    refIdMap: {}, // map indexed by refId
     lookupRefIdData: function(refId) {
-        var settings = this.refIdMap[refId];
+		var surveyStateMgmt = this._getSurveyStateMgmt();
+		if ( !('refIdMap' in surveyStateMgmt) ) {
+			surveyStateMgmt.refIdMap = {};
+		} 
+        var settings = surveyStateMgmt.refIdMap[refId];
         if ( settings === undefined || settings === null ) {
             settings = {
                 instanceId: null,
                 sectionStateScreenHistory: []
             };
-            this.refIdMap[refId] = settings;
+            surveyStateMgmt.refIdMap[refId] = settings;
         }
         return settings;
     },
     clearInstanceId: function( refId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: clearInstanceId(" + refId + ")");
             return;
         }
@@ -50,7 +71,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         settings.instanceId = null;
     },
     setInstanceId: function( refId, instanceId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: setInstanceId(" + refId + ", " + instanceId + ")");
             return;
         }
@@ -62,7 +83,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         settings.instanceId = instanceId;
     },
     getInstanceId: function( refId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: getInstanceId(" + refId + ")");
             return null;
         }
@@ -98,7 +119,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         odkCommon.log("D","odkSurveyStateManagement ------------- *end*  dumpScreenStateHistory--------------------");
     },
     pushSectionScreenState: function( refId) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: pushSectionScreenState(" + refId + ")");
             return;
         }
@@ -114,7 +135,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         lastSection.history.push( { screen: lastSection.screen, state: lastSection.state } );
     },
     setSectionScreenState: function( refId, screenPath, state) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: setSectionScreenState(" + refId + ", " + screenPath + ", " + state + ")");
             return;
         }
@@ -142,7 +163,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         }
     },
     clearSectionScreenState: function( refId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: clearSectionScreenState(" + refId + ")");
             return;
         }
@@ -152,7 +173,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         settings.sectionStateScreenHistory = [ { history: [], screen: 'initial/0', state: null } ];
     },
     getControllerState: function( refId ) {
-        if (this.enforceRefIdMatch && refId != this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: getControllerState(" + refId + ")");
             return null;
         }
@@ -167,7 +188,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         return lastSection.state;
     },
     getScreenPath: function(refId) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: getScreenPath(" + refId + ")");
             return null;
         }
@@ -183,7 +204,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         return lastSection.screen;
     },
     hasScreenHistory: function( refId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: hasScreenHistory(" + refId + ")");
             return false;
         }
@@ -202,7 +223,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         return ( thisSection.history.length !== 0 );
     },
     popScreenHistory: function( refId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: popScreenHistory(" + refId + ")");
             return null;
         }
@@ -238,7 +259,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
      * Section stack -- maintains the stack of sections from which you can exit.
      */
     hasSectionStack: function( refId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: hasSectionStack(" + refId + ")");
             return false;
         }
@@ -247,7 +268,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         return settings.sectionStateScreenHistory.length !== 0;
     },
     popSectionStack: function( refId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: popSectionStack(" + refId + ")");
             return null;
         }
@@ -265,7 +286,7 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         return null;
     },
     frameworkHasLoaded: function(refId, outcome) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: frameworkHasLoaded(" + refId + ", " + outcome + ")");
             return;
         }
@@ -273,20 +294,18 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         if ( this.showAlerts ) alert("notify container frameworkHasLoaded " + (outcome ? "SUCCESS" : "FAILURE"));
     },
     saveAllChangesCompleted: function( refId, instanceId, asComplete ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: saveAllChangesCompleted(" + refId + ", " + instanceId + ", " + asComplete + ")");
             return;
         }
         odkCommon.log("D","odkSurveyStateManagement: DO: saveAllChangesCompleted(" + refId + ", " + instanceId + ", " + asComplete + ")");
         if ( this.showAlerts ) alert("notify container OK save " + (asComplete ? 'COMPLETE' : 'INCOMPLETE') + '.');
-        if ( window.parent === window ) {
-            window.close();
-        } else {
-            window.parent.closeAndPopPage();
-        }
+		odkCommon.closeWindow(-1, {
+			instanceId: instanceId, 
+			savepoint_type: (asComplete ? 'COMPLETE' : 'INCOMPLETE') } );
     },
     saveAllChangesFailed: function( refId, instanceId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: saveAllChangesFailed(" + refId + ", " + instanceId + ")");
             return;
         }
@@ -294,20 +313,19 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
         if ( this.showAlerts ) alert("notify container FAILED save (unknown whether COMPLETE or INCOMPLETE was attempted).");
     },
     ignoreAllChangesCompleted: function( refId, instanceId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: ignoreAllChangesCompleted(" + refId + ", " + instanceId + ")");
             return;
         }
         odkCommon.log("D","odkSurveyStateManagement: DO: ignoreAllChangesCompleted(" + refId + ", " + instanceId + ")");
         if ( this.showAlerts ) alert("notify container OK ignore all changes.");
-        if ( window.parent === window ) {
-            window.close();
-        } else {
-            window.parent.closeAndPopPage();
-        }
+		// TODO: should we return current savepoint_type for this row?
+		odkCommon.closeWindow(-1, {
+			instanceId: instanceId, 
+			savepoint_type: 'INCOMPLETE' } );
     },
     ignoreAllChangesFailed: function( refId, instanceId ) {
-        if (this.enforceRefIdMatch && refId !== this.refId) {
+        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: ignoreAllChangesFailed(" + refId + ", " + instanceId + ")");
             return;
         }

--- a/app/system/survey/js/parsequery.js
+++ b/app/system/survey/js/parsequery.js
@@ -243,7 +243,7 @@ return {
 
             if ( formPath !== null &&  formPath !== undefined &&
                  formPath.length > 0 && formPath[formPath.length-1] !== '/' ) {
-                formPath[formPath.length] = '/';
+                formPath = formPath + '/';
             }
         }
 
@@ -261,7 +261,9 @@ return {
 
         // This may fail when embedded
         try {
-            odkSurveyStateManagement.refId = refId;
+			if ( '_setRefId' in odkSurveyStateManagement ) {
+			  odkSurveyStateManagement._setRefId(refId);
+			}
         } catch(e) {
             ctxt.log('W','parsequery._parseParameters.odkSurveyStateManagement.refId assignment failed (ok if embedded)');
         }


### PR DESCRIPTION
1. Pass dataTableModel and canCreateRow through mock odkDataIf. 

2. Change survey database.js to use dataTableModel coming through interface (the authoritative value should come from Java side, not from formDef.json).

3. Alter mock implementation of odkSurveyStateManagement to use storage object (_nonEmbeddedState). This is a partial port of changes from website prototype.

4. Update append-string in parsequery to modern usage (lint).
