### PR TITLE
metadata cache propagation to JS layer

### DIFF
--- a/app/system/js/mock/odkDataIf.js
+++ b/app/system/js/mock/odkDataIf.js
@@ -304,21 +304,21 @@ var odkDataIf = {
             var colDefs = [];
 
             for ( var dbColumnName in def.dataTableModel ) {
-				if ( def.dataTableModel.hasOwnProperty(dbColumnName) ) {
-					// the XLSXconverter already handles expanding complex types
-					// such as geopoint into their underlying storage representation.
-					var jsonDefn = def.dataTableModel[dbColumnName];
+                if ( def.dataTableModel.hasOwnProperty(dbColumnName) ) {
+                    // the XLSXconverter already handles expanding complex types
+                    // such as geopoint into their underlying storage representation.
+                    var jsonDefn = def.dataTableModel[dbColumnName];
 
-					if ( jsonDefn.elementSet === 'data' && !jsonDefn.isSessionVariable ) {
-						colDefs.push( {
-							_table_id: tableId,
-							_element_key: dbColumnName,
-							_element_name: jsonDefn.elementName,
-							_element_type: (jsonDefn.elementType === undefined || jsonDefn.elementType === null ? jsonDefn.type : jsonDefn.elementType),
-							_list_child_element_keys : ((jsonDefn.listChildElementKeys === undefined || jsonDefn.listChildElementKeys === null) ? JSON.stringify([]) : JSON.stringify(jsonDefn.listChildElementKeys))
-						} );
-					}
-				}
+                    if ( jsonDefn.elementSet === 'data' && !jsonDefn.isSessionVariable ) {
+                        colDefs.push( {
+                            _table_id: tableId,
+                            _element_key: dbColumnName,
+                            _element_name: jsonDefn.elementName,
+                            _element_type: (jsonDefn.elementType === undefined || jsonDefn.elementType === null ? jsonDefn.type : jsonDefn.elementType),
+                            _list_child_element_keys : ((jsonDefn.listChildElementKeys === undefined || jsonDefn.listChildElementKeys === null) ? JSON.stringify([]) : JSON.stringify(jsonDefn.listChildElementKeys))
+                        } );
+                    }
+                }
             }
             // create the data table
             ctxt.sqlStatement = mockSchema.createTableStmt(tableId, def.dataTableModel);
@@ -419,117 +419,117 @@ var odkDataIf = {
                             // initialize the elementNameMap
                             j = 0;
                             for ( f in row ) {
-								if ( row.hasOwnProperty(f) ) {
-									elementNameMap[f] = j;
-									++j;
-								}
+                                if ( row.hasOwnProperty(f) ) {
+                                    elementNameMap[f] = j;
+                                    ++j;
+                                }
                             }
                         }
                         rowArray = [];
                         for ( f in row ) {
-							if ( row.hasOwnProperty(f) ) {
-								mdlf = f;
-								if ( f.lastIndexOf('.') != -1 ) {
-									mdlf = f.substring(f.lastIndexOf('.')+1);
-								}
-								defElement = tableDef.dataTableModel[mdlf];
-								if ( defElement === null || defElement === undefined ) {
-									dbValue = row[f];
-									// don't do any conversion
-									rowArray.push(dbValue);
-								} else if ( mockUtils.isUnitOfRetention(defElement) && !defElement.isSessionVariable ) {
-									dbValue = row[f];
-									value = mockUtils.fromDatabaseToOdkDataInterfaceElementType( defElement, dbValue );
-									rowArray.push(value);
-								}
-							}
+                            if ( row.hasOwnProperty(f) ) {
+                                mdlf = f;
+                                if ( f.lastIndexOf('.') != -1 ) {
+                                    mdlf = f.substring(f.lastIndexOf('.')+1);
+                                }
+                                defElement = tableDef.dataTableModel[mdlf];
+                                if ( defElement === null || defElement === undefined ) {
+                                    dbValue = row[f];
+                                    // don't do any conversion
+                                    rowArray.push(dbValue);
+                                } else if ( mockUtils.isUnitOfRetention(defElement) && !defElement.isSessionVariable ) {
+                                    dbValue = row[f];
+                                    value = mockUtils.fromDatabaseToOdkDataInterfaceElementType( defElement, dbValue );
+                                    rowArray.push(value);
+                                }
+                            }
                         }
                         resultRows.push(rowArray);
                     }
 
-					if ( $.isEmptyObject(elementNameMap) ) {
-						// fake it -- assume these are in the order they appear in dataTableModel
-						i = 0;
-						for ( f in tableDef.dataTableModel ) {
-							if ( tableDef.dataTableModel.hasOwnProperty(f) ) {
-								var entry = tableDef.dataTableModel[f];
-								if ( !entry.isSessionVariable && !entry.notUnitOfRetention ) {
-									elementNameMap[entry.elementKey] = i;
-									++i;
-								}
-							}
-						}
-					}
+                    if ( $.isEmptyObject(elementNameMap) ) {
+                        // fake it -- assume these are in the order they appear in dataTableModel
+                        i = 0;
+                        for ( f in tableDef.dataTableModel ) {
+                            if ( tableDef.dataTableModel.hasOwnProperty(f) ) {
+                                var entry = tableDef.dataTableModel[f];
+                                if ( !entry.isSessionVariable && !entry.notUnitOfRetention ) {
+                                    elementNameMap[entry.elementKey] = i;
+                                    ++i;
+                                }
+                            }
+                        }
+                    }
                     content.data = resultRows;
-					content.metadata = {};
+                    content.metadata = {};
                     content.metadata.tableId = tableDef.tableId;
                     content.metadata.schemaETag = tableDef.schemaETag;
                     content.metadata.lastDataETag = tableDef.lastDataETag;
                     content.metadata.lastSyncTime = tableDef.lastSyncTime;
                     content.metadata.elementKeyMap = elementNameMap;
-					// TODO: determine the correct value for this
-					content.metadata.canCreateRow = true;
-					// HACK: always use the cached metadata if it is present
-					var metaDataRev = window.odkData._getTableMetadataRevision(tableDef.tableId);
-					if ( metaDataRev === null || metaDataRev === undefined ) {
-						content.metadata.cachedMetadata = {};
-						// this can be any value...
-						metaDataRev = that.eventCount;
-						content.metadata.cachedMetadata.metaDataRev = metaDataRev;
-						
-						// the tableDef.dataTableModel is fully expanded. Create the minimal
-						// model by removing the nested elements from the list. Those are the 
-						// ones with an elementPath !== elementKey.
-						var dataTableModelAdjusted = {};
-						var ddef; 
-						
-						for ( f in tableDef.dataTableModel ) {
-							if ( tableDef.dataTableModel.hasOwnProperty(f) ) {
-								ddef = tableDef.dataTableModel[f];
-								if ( ddef.elementPath === ddef.elementKey ) {
-									dataTableModelAdjusted[f] = ddef;
-								}
-							}
-						}
-						content.metadata.cachedMetadata.dataTableModel = dataTableModelAdjusted;
-						// synthesize the choiceListMap and the choice-compressed keyValueStoreList
-						// the later is the same as the tableDef.keyValueStoreList except that 
-						// any displayChoicesList is collapsed into a property string and the value is moved
-						// into the choiceListMap, referenced by that property string.
-						var choiceNamesMap = {};
-						var kvsListAdjusted = [];
-						var fmatch;
-						var kvs;
-						var kvsNew;
-						for ( i = 0 ; i < tableDef.keyValueStoreList.length ; ++i ) {
-							kvs = tableDef.keyValueStoreList[i];
-							if ( kvs.partition === "Column" && 
-								 kvs.key === "displayChoicesList" && 
-								 kvs.value !== null ) {
-								fmatch = null;
-								for ( f in choiceNamesMap ) {
-									if ( choiceNamesMap.hasOwnProperty(f) ) {
-										ddef = choiceNamesMap[f];
-										if ( ddef === kvs.value ) {
-											fmatch = f;
-											break;
-										}
-									}
-								}
-								if ( fmatch === null ) {
-								    fmatch = 'a_' + i;
-									choiceNamesMap[fmatch] = kvs.value;
-								}
-								kvsNew = $.extend({}, kvs);
-								kvsNew.value = fmatch;
-								kvsListAdjusted.push(kvsNew);
-							} else {
-								kvsListAdjusted.push(kvs);
-							}
-						}
-						content.metadata.cachedMetadata.keyValueStoreList = kvsListAdjusted;
-						content.metadata.cachedMetadata.choiceListMap = choiceNamesMap;
-					}
+                    // TODO: determine the correct value for this
+                    content.metadata.canCreateRow = true;
+                    // HACK: always use the cached metadata if it is present
+                    var metaDataRev = window.odkData._getTableMetadataRevision(tableDef.tableId);
+                    if ( metaDataRev === null || metaDataRev === undefined ) {
+                        content.metadata.cachedMetadata = {};
+                        // this can be any value...
+                        metaDataRev = that.eventCount;
+                        content.metadata.cachedMetadata.metaDataRev = metaDataRev;
+                        
+                        // the tableDef.dataTableModel is fully expanded. Create the minimal
+                        // model by removing the nested elements from the list. Those are the 
+                        // ones with an elementPath !== elementKey.
+                        var dataTableModelAdjusted = {};
+                        var ddef; 
+                        
+                        for ( f in tableDef.dataTableModel ) {
+                            if ( tableDef.dataTableModel.hasOwnProperty(f) ) {
+                                ddef = tableDef.dataTableModel[f];
+                                if ( ddef.elementPath === ddef.elementKey ) {
+                                    dataTableModelAdjusted[f] = ddef;
+                                }
+                            }
+                        }
+                        content.metadata.cachedMetadata.dataTableModel = dataTableModelAdjusted;
+                        // synthesize the choiceListMap and the choice-compressed keyValueStoreList
+                        // the later is the same as the tableDef.keyValueStoreList except that 
+                        // any displayChoicesList is collapsed into a property string and the value is moved
+                        // into the choiceListMap, referenced by that property string.
+                        var choiceNamesMap = {};
+                        var kvsListAdjusted = [];
+                        var fmatch;
+                        var kvs;
+                        var kvsNew;
+                        for ( i = 0 ; i < tableDef.keyValueStoreList.length ; ++i ) {
+                            kvs = tableDef.keyValueStoreList[i];
+                            if ( kvs.partition === "Column" && 
+                                 kvs.key === "displayChoicesList" && 
+                                 kvs.value !== null ) {
+                                fmatch = null;
+                                for ( f in choiceNamesMap ) {
+                                    if ( choiceNamesMap.hasOwnProperty(f) ) {
+                                        ddef = choiceNamesMap[f];
+                                        if ( ddef === kvs.value ) {
+                                            fmatch = f;
+                                            break;
+                                        }
+                                    }
+                                }
+                                if ( fmatch === null ) {
+                                    fmatch = 'a_' + i;
+                                    choiceNamesMap[fmatch] = kvs.value;
+                                }
+                                kvsNew = $.extend({}, kvs);
+                                kvsNew.value = fmatch;
+                                kvsListAdjusted.push(kvsNew);
+                            } else {
+                                kvsListAdjusted.push(kvs);
+                            }
+                        }
+                        content.metadata.cachedMetadata.keyValueStoreList = kvsListAdjusted;
+                        content.metadata.cachedMetadata.choiceListMap = choiceNamesMap;
+                    }
                 });
         });
     },
@@ -570,14 +570,14 @@ var odkDataIf = {
             orderByElementKey, orderByDirection, limit, offset, includeKVS, metaDataRev, _callbackId) {
         var that = this;
 
-		var sqlBindParams = (sqlBindParamsJSON === null || sqlBindParamsJSON === undefined) ?
-			[] : JSON.parse(sqlBindParamsJSON);
-			
+        var sqlBindParams = (sqlBindParamsJSON === null || sqlBindParamsJSON === undefined) ?
+            [] : JSON.parse(sqlBindParamsJSON);
+            
         var ctxt = that.newStartContext(_callbackId);
 
         that._getTableDef($.extend({}, ctxt, {
             success: function(tableDef) {
-				// TODO: row filtering
+                // TODO: row filtering
                 var sql = 'SELECT * FROM "' + tableId + '"';
                 if ( whereClause !== null && whereClause !== undefined ) {
                     sql = sql + " WHERE " + whereClause;
@@ -598,8 +598,8 @@ var odkDataIf = {
                 var sqlStatement = {
                         stmt : sql,
                         bind : sqlBindParams,
-						limit : limit,
-						offset : offset
+                        limit : limit,
+                        offset : offset
                     };
                 that._constructResponse(ctxt, tableDef, sqlStatement);
             }
@@ -609,9 +609,9 @@ var odkDataIf = {
     arbitraryQuery: function(tableId, sqlCommand, sqlBindParamsJSON, limit, offset, metaDataRev, _callbackId) {
         var that = this;
 
-		// TODO: row filtering
-		var sqlBindParams = (sqlBindParamsJSON === null || sqlBindParamsJSON === undefined) ?
-			[] : JSON.parse(sqlBindParamsJSON);
+        // TODO: row filtering
+        var sqlBindParams = (sqlBindParamsJSON === null || sqlBindParamsJSON === undefined) ?
+            [] : JSON.parse(sqlBindParamsJSON);
 
         var ctxt = that.newStartContext(_callbackId);
 
@@ -620,8 +620,8 @@ var odkDataIf = {
                 var sqlStatement = {
                         stmt : sqlCommand,
                         bind : sqlBindParams,
-						limit : limit,
-						offset : offset
+                        limit : limit,
+                        offset : offset
                     };
                 that._constructResponse(ctxt, tableDef, sqlStatement);
             }
@@ -640,7 +640,7 @@ var odkDataIf = {
 
         that._getTableDef($.extend({}, ctxt, {
             success: function(tableDef) {
-				// TODO: row filtering
+                // TODO: row filtering
                 var sqlStatement = {
                         stmt : 'select * from "' + tableId + '" where _id=?',
                         bind : [ rowId ]
@@ -653,7 +653,7 @@ var odkDataIf = {
     _getMostRecentRow: function( ctxt, tableDef, rowId ) {
         var that = this;
 
-		// TODO: row filtering
+        // TODO: row filtering
         var sqlStatement =  {
             stmt : 'select * from "' + tableDef.tableId + '" as T where _id=? and ' +
                     'T._savepoint_timestamp=(select max(V._savepoint_timestamp) from "' +

--- a/app/system/js/odkCommon.js
+++ b/app/system/js/odkCommon.js
@@ -91,6 +91,7 @@ window.odkCommon = {
         // NOTE: users should invoke the listener once to ensure that 
         // any queued actions are processed. This should be done after
         // all page initialization is complete.
+        odkCommonIf.frameworkHasLoaded();
     },
     /**
      * @return true if there is a listener already registered
@@ -987,9 +988,22 @@ window.odkCommon = {
 if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
     window.odkCommonIf = {
         _sessionVariables: {},
+        _frameworkHasLoaded: false,
         _queuedActions: [],
         _logLevel: 'D',
         _XRegExp: null,
+        frameworkHasLoaded: function() {
+            var that = this;
+            that._frameworkHasLoaded = true;
+        },
+        _signalCallback: function() {
+            var that = this;
+            if ( that._frameworkHasLoaded ) {
+                setTimeout(function() {
+                odkCommon.signalQueuedActionAvailable();
+              }, 100);
+            }
+        },
         getPlatformInfo : function() {
             var that = this;
             // 9000 b/c that's what grunt is running on. Perhaps should configure
@@ -1016,7 +1030,6 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
             var result = JSON.stringify(platformInfo);
             return result;
         },
-
         getFileAsUrl: function(relativePath) {
             var that = this;
             // strip off backslashes
@@ -1207,9 +1220,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: { uriFragment: "system/survey/test/venice.jpg",
                                                        contentType: "image/jpg" } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 100);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.MediaCaptureVideoActivity' ) {
@@ -1217,9 +1228,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: { uriFragment: "system/survey/test/bali.3gp",
                                                        contentType: "video/3gp" } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 100);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.MediaCaptureAudioActivity' ) {
@@ -1227,9 +1236,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: { uriFragment: "system/survey/test/raven.wav",
                                                        contentType: "audio/wav" } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 100);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.MediaChooseImageActivity' ) {
@@ -1237,9 +1244,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: { uriFragment: "system/survey/test/venice.jpg",
                                                        contentType: "image/jpg" } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 100);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.MediaChooseVideoActivity' ) {
@@ -1247,9 +1252,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: { uriFragment: "system/survey/test/bali.3gp",
                                                        contentType: "video/3gp" } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 100);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.MediaChooseAudioActivity' ) {
@@ -1257,9 +1260,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: { uriFragment: "system/survey/test/raven.wav",
                                                        contentType: "audio/wav" } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 100);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.sensors.PULSEOX' ) {
@@ -1268,9 +1269,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: { pulse: 100,
                                                        ox: oxValue } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 1000);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'change.uw.android.BREATHCOUNT' ) {
@@ -1278,9 +1277,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                 that._queuedActions.push(
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: {  value: breathCount } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 1000);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'com.google.zxing.client.android.SCAN' ) {
@@ -1288,9 +1285,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                 that._queuedActions.push(
                   JSON.stringify({ dispatchStruct: dispatchStruct, action: action,
                     jsonValue: { status: -1, result: {  SCAN_RESULT: barcode } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 1000);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.GeoPointMapActivity' ) {
@@ -1304,9 +1299,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                                                        longitude: lng,
                                                        altitude: alt,
                                                        accuracy: acc } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 1000);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.GeoPointActivity' ) {
@@ -1320,9 +1313,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                                                        longitude: lng,
                                                        altitude: alt,
                                                        accuracy: acc } } }));
-                setTimeout(function() {
-                    odkCommon.signalQueuedActionAvailable();
-                }, 1000);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.MainMenuActivity' ) {
@@ -1337,10 +1328,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                     // inside tab1
                     window.parent.pushPageAndOpen(value.extras.url);
                 }
-                setTimeout(function() {
-                    that.log("D","Opened new browser window for Survey content. Close to continue");
-                    odkCommon.signalQueuedActionAvailable();
-                }, 1000);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'org.opendatakit.survey.activities.SplashScreenActivity' ) {
@@ -1355,10 +1343,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                     // inside tab1
                     window.parent.pushPageAndOpen(value.extras.url);
                 }
-                setTimeout(function() {
-                    that.log("D","Opened new browser window for link to another ODK Survey page. Close to continue");
-                    odkCommon.signalQueuedActionAvailable();
-                }, 1000);
+                that._signalCallback();
                 return "OK";
             }
             if ( action === 'android.content.Intent.ACTION_VIEW' ) {
@@ -1373,10 +1358,7 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                     // inside tab1
                     window.parent.pushPageAndOpen(value.extras.url);
                 }
-                setTimeout(function() {
-                    that.log("D","Opened new browser window for 3rd party content. Close to continue");
-                    odkCommon.signalQueuedActionAvailable();
-                }, 1000);
+                that._signalCallback();
                 return "OK";
             }
         },

--- a/app/system/js/odkCommon.js
+++ b/app/system/js/odkCommon.js
@@ -79,29 +79,29 @@ window.odkCommon = {
      *                   odkCommon.removeFirstQueuedAction();
      *               }
      *            });
-	 *
-	 * Users of odkCommon should invoke this listener function 
-	 * once, themselves, after registration, to ensure that any
-	 * queued action is processed. They should do this after all
-	 * initialization is complete.
+     *
+     * Users of odkCommon should invoke this listener function 
+     * once, themselves, after registration, to ensure that any
+     * queued action is processed. They should do this after all
+     * initialization is complete.
      */
     registerListener: function(listener) {
         var that = this;
         that._listener = listener;
-		// NOTE: users should invoke the listener once to ensure that 
-		// any queued actions are processed. This should be done after
-		// all page initialization is complete.
+        // NOTE: users should invoke the listener once to ensure that 
+        // any queued actions are processed. This should be done after
+        // all page initialization is complete.
     },
-	/**
-	 * @return true if there is a listener already registered
-	 */
-	hasListener: function() {
-		var that = this;
-		if ( that._listener !== undefined && that._listener !== null ) {
-			return true;
-		}
-		return false;
-	},
+    /**
+     * @return true if there is a listener already registered
+     */
+    hasListener: function() {
+        var that = this;
+        if ( that._listener !== undefined && that._listener !== null ) {
+            return true;
+        }
+        return false;
+    },
     /**
      * callback from Java side to notify of data available.
      */
@@ -148,241 +148,241 @@ window.odkCommon = {
    
    /**
     * predicate definition copied from underscore library
-	*/
+    */
    isString: function(obj) {
-		return (obj !== undefined) && (obj !== null) && (Object.prototype.toString.call(obj) === "[object String]");
+        return (obj !== undefined) && (obj !== null) && (Object.prototype.toString.call(obj) === "[object String]");
    },
    
    /**
     * Return the content of a display object for the given token.
-	* Note that this might include text, hint, image, etc. that 
-	* are then localizable.
-	*
-	* In general, the resulting object can be customized further
-	* in survey XLSX files by specifying overrides for these fields.
-	*/
+    * Note that this might include text, hint, image, etc. that 
+    * are then localizable.
+    *
+    * In general, the resulting object can be customized further
+    * in survey XLSX files by specifying overrides for these fields.
+    */
    lookupToken:function(stringToken) {
-	  if (stringToken === undefined || stringToken === null) {
-		  return undefined;
-	  }
+      if (stringToken === undefined || stringToken === null) {
+          return undefined;
+      }
       if(!this.isString(stringToken)) {
           return stringToken;
       }
-	  var foundFramework = ('odkFrameworkDefinitions' in window &&
-		   (window.odkFrameworkDefinitions !== undefined) &&
-   	       (window.odkFrameworkDefinitions !== null) &&
-		   stringToken in window.odkFrameworkDefinitions._tokens );
-	  var foundCommon = ('odkCommonDefinitions' in window &&
-		   (window.odkCommonDefinitions !== undefined) &&
-   	       (window.odkCommonDefinitions !== null) &&
-		   stringToken in window.odkCommonDefinitions._tokens );
-	  var foundTableSpecific = ('odkTableSpecificDefinitions' in window &&
-	       (window.odkTableSpecificDefinitions !== undefined) &&
-   	       (window.odkTableSpecificDefinitions !== null) &&
-		   stringToken in window.odkTableSpecificDefinitions._tokens );
-	
-	  var countFound = (foundFramework ? 1 : 0) + (foundCommon ? 1 : 0) + (foundTableSpecific ? 1 : 0);
-	  if ( countFound > 1 ) {
-		  return 'string_token('+stringToken+')--defined-multiple-places';
-	  }
-	  if ( foundTableSpecific ) {
-		// found it in table-specific translations
-		return window.odkTableSpecificDefinitions._tokens[stringToken];
-	  }
-	  if ( foundCommon ) {
-		// found it in common translations
-		return window.odkCommonDefinitions._tokens[stringToken];
-	  }
-	  if ( foundFramework ) {
-		// found it in framework translations
-		return window.odkFrameworkDefinitions._tokens[stringToken];
-	  }
-	  return undefined;
+      var foundFramework = ('odkFrameworkDefinitions' in window &&
+           (window.odkFrameworkDefinitions !== undefined) &&
+           (window.odkFrameworkDefinitions !== null) &&
+           stringToken in window.odkFrameworkDefinitions._tokens );
+      var foundCommon = ('odkCommonDefinitions' in window &&
+           (window.odkCommonDefinitions !== undefined) &&
+           (window.odkCommonDefinitions !== null) &&
+           stringToken in window.odkCommonDefinitions._tokens );
+      var foundTableSpecific = ('odkTableSpecificDefinitions' in window &&
+           (window.odkTableSpecificDefinitions !== undefined) &&
+           (window.odkTableSpecificDefinitions !== null) &&
+           stringToken in window.odkTableSpecificDefinitions._tokens );
+    
+      var countFound = (foundFramework ? 1 : 0) + (foundCommon ? 1 : 0) + (foundTableSpecific ? 1 : 0);
+      if ( countFound > 1 ) {
+          return 'string_token('+stringToken+')--defined-multiple-places';
+      }
+      if ( foundTableSpecific ) {
+        // found it in table-specific translations
+        return window.odkTableSpecificDefinitions._tokens[stringToken];
+      }
+      if ( foundCommon ) {
+        // found it in common translations
+        return window.odkCommonDefinitions._tokens[stringToken];
+      }
+      if ( foundFramework ) {
+        // found it in framework translations
+        return window.odkFrameworkDefinitions._tokens[stringToken];
+      }
+      return undefined;
    },
    i18nFieldNames: [ 'text', 'image', 'audio', 'video' ],
    
    extractLangOnlyLocale: function(locale) {
-	  // Device locale strings are of the form: language + "_" + country
-	  // Allow for generic language translations and for country-specific langauge 
-	  // translations.
-	  var idxUnderscore = locale.indexOf('_');
-	  if ( idxUnderscore > 0) {
-		  return locale.substring(0,idxUnderscore);
-	  }
-	  return null;
+      // Device locale strings are of the form: language + "_" + country
+      // Allow for generic language translations and for country-specific langauge 
+      // translations.
+      var idxUnderscore = locale.indexOf('_');
+      if ( idxUnderscore > 0) {
+          return locale.substring(0,idxUnderscore);
+      }
+      return null;
    },
    
    /**
     * Return the locale that was configured by the user in the Java-side's Device Settings.
-	*/
+    */
    getPreferredLocale: function() {
-	   var pi = this.getPlatformInfo();
-	   var obj = JSON.parse(pi);
-	   return obj.preferredLocale;
+       var pi = this.getPlatformInfo();
+       var obj = JSON.parse(pi);
+       return obj.preferredLocale;
    },
    
    /**
     * Get details about the preferred locale and the Device's locale setting.
-	* And also whether or not the preferred locale (above) is (just) the Device
-	* locale.
-	* Note that the user may have set the preferred locale to be "en_US" and the
-	* device locale may also happen to be "en_US". In this case, usingDeviceLocale
-	* is false. Only if the user chooses to use the device locale (vs. one of the 
-	* locales defined in the common translations) will this be true.
-	*/
+    * And also whether or not the preferred locale (above) is (just) the Device
+    * locale.
+    * Note that the user may have set the preferred locale to be "en_US" and the
+    * device locale may also happen to be "en_US". In this case, usingDeviceLocale
+    * is false. Only if the user chooses to use the device locale (vs. one of the 
+    * locales defined in the common translations) will this be true.
+    */
    getLocaleDetails: function() {
-	   var pi = this.getPlatformInfo();
-	   var obj = JSON.parse(pi);
-	   var info = {
-			preferredLocale: obj.preferredLocale,
-			// true only if user did not override the device locale
-			usingDeviceLocale: obj.usingDeviceLocale,
-			// info about the device locale:
-			isoCountry: obj.isoCountry,
-			displayCountry: obj.displayCountry,
-			isoLanguage: obj.isoLanguage,
-			displayLanguage: obj.displayLanguage };
-			
-	   // and, finally if the device supports it, report the BCP47 tag:
-	   if ( 'bcp47LanguageTag' in obj ) {
-		  info.bcp47LanguageTag = obj.bcp47LanguageTag;
-	   }
-	   return info;
+       var pi = this.getPlatformInfo();
+       var obj = JSON.parse(pi);
+       var info = {
+            preferredLocale: obj.preferredLocale,
+            // true only if user did not override the device locale
+            usingDeviceLocale: obj.usingDeviceLocale,
+            // info about the device locale:
+            isoCountry: obj.isoCountry,
+            displayCountry: obj.displayCountry,
+            isoLanguage: obj.isoLanguage,
+            displayLanguage: obj.displayLanguage };
+            
+       // and, finally if the device supports it, report the BCP47 tag:
+       if ( 'bcp47LanguageTag' in obj ) {
+          info.bcp47LanguageTag = obj.bcp47LanguageTag;
+       }
+       return info;
    },
    
    /**
     * Return true if there is some type of localization for the given i18nToken and locale
-	* OR if there is a 'default' localization value.
-	*
-	* The localization might be a text, image, audio or video element. i.e., the field name
-	* that can be localized is not specified.
+    * OR if there is a 'default' localization value.
+    *
+    * The localization might be a text, image, audio or video element. i.e., the field name
+    * that can be localized is not specified.
     */
    hasLocalization:function(locale, i18nToken) {
-	  var textOrLangMap = this.lookupToken(i18nToken);
-	  if (textOrLangMap === undefined ) {
-		  return false;
-	  }
+      var textOrLangMap = this.lookupToken(i18nToken);
+      if (textOrLangMap === undefined ) {
+          return false;
+      }
       if(this.isString(textOrLangMap)) {
           return true;
       }
-	  
-	  // Device locale strings are of the form: language + "_" + country
-	  // Allow for generic language translations and for country-specific langauge 
-	  // translations.
-	  var langOnlyLocale = this.extractLangOnlyLocale(locale);
-	  
-	  // the keys in the textOrLangMap are one of: text, image, audio, video
-	  // see if any of these have a localization.
-	  for ( var i = 0 ; i < this.i18nFieldNames.length ; ++i ) {
-		var fieldName = this.i18nFieldNames[i];
-		if ( fieldName in textOrLangMap ) {
-		  var textMap = textOrLangMap[fieldName];
-		  if(this.isString(textMap)) {
-			  return true;
-		  } else if( locale in textMap ) {
-			  return true;
-		  } else if ( langOnlyLocale !== null && langOnlyLocale in textMap ) {
-			  return true;
-		  } else if ( 'default' in textMap ) {
-			  return true;
-		  }
-		}
-	  }
-	  return false;
+      
+      // Device locale strings are of the form: language + "_" + country
+      // Allow for generic language translations and for country-specific langauge 
+      // translations.
+      var langOnlyLocale = this.extractLangOnlyLocale(locale);
+      
+      // the keys in the textOrLangMap are one of: text, image, audio, video
+      // see if any of these have a localization.
+      for ( var i = 0 ; i < this.i18nFieldNames.length ; ++i ) {
+        var fieldName = this.i18nFieldNames[i];
+        if ( fieldName in textOrLangMap ) {
+          var textMap = textOrLangMap[fieldName];
+          if(this.isString(textMap)) {
+              return true;
+          } else if( locale in textMap ) {
+              return true;
+          } else if ( langOnlyLocale !== null && langOnlyLocale in textMap ) {
+              return true;
+          } else if ( 'default' in textMap ) {
+              return true;
+          }
+        }
+      }
+      return false;
    },
    
    hasFieldLocalization:function(locale, i18nToken, fieldName) {
-	  var textOrLangMap = this.lookupToken(i18nToken);
-	  if (textOrLangMap === undefined ) {
-		  return false;
-	  }
+      var textOrLangMap = this.lookupToken(i18nToken);
+      if (textOrLangMap === undefined ) {
+          return false;
+      }
       if(this.isString(textOrLangMap)) {
           return true;
       }
-		  
-	  // Device locale strings are of the form: language + "_" + country
-	  // Allow for generic language translations and for country-specific langauge 
-	  // translations.
-	  var langOnlyLocale = this.extractLangOnlyLocale(locale);
+          
+      // Device locale strings are of the form: language + "_" + country
+      // Allow for generic language translations and for country-specific langauge 
+      // translations.
+      var langOnlyLocale = this.extractLangOnlyLocale(locale);
   
-	  if ( fieldName in textOrLangMap ) {
-		  var textMap = textOrLangMap[fieldName];
-		  if(this.isString(textMap)) {
-			  return true;
-		  } else if( locale in textMap ) {
-			  return true;
-		  } else if ( langOnlyLocale !== null && langOnlyLocale in textMap ) {
-			  return true;
-		  } else if ( 'default' in textMap ) {
-			  return true;
-		  }
-	  }
-	  return false;
+      if ( fieldName in textOrLangMap ) {
+          var textMap = textOrLangMap[fieldName];
+          if(this.isString(textMap)) {
+              return true;
+          } else if( locale in textMap ) {
+              return true;
+          } else if ( langOnlyLocale !== null && langOnlyLocale in textMap ) {
+              return true;
+          } else if ( 'default' in textMap ) {
+              return true;
+          }
+      }
+      return false;
    },
    
    localizeTokenField:function(locale, i18nToken, fieldName) {
-	  var textOrLangMap = this.lookupToken(i18nToken);
-	  if (textOrLangMap === undefined ) {
-		  return undefined;
-	  }
+      var textOrLangMap = this.lookupToken(i18nToken);
+      if (textOrLangMap === undefined ) {
+          return undefined;
+      }
       if(this.isString(textOrLangMap)) {
           return textOrLangMap;
       }
-	  if ( !(fieldName in textOrLangMap) ) {
-		  return undefined;
-	  }
-	  var textMap = textOrLangMap[fieldName];
+      if ( !(fieldName in textOrLangMap) ) {
+          return undefined;
+      }
+      var textMap = textOrLangMap[fieldName];
       if(this.isString(textMap)) {
           return textMap;
       }
 
-	  // Device locale strings are of the form: language + "_" + country
-	  // Allow for generic language translations and for country-specific langauge 
-	  // translations.
-	  var langOnlyLocale = this.extractLangOnlyLocale(locale);
+      // Device locale strings are of the form: language + "_" + country
+      // Allow for generic language translations and for country-specific langauge 
+      // translations.
+      var langOnlyLocale = this.extractLangOnlyLocale(locale);
 
       if( locale in textMap ) {
           return textMap[locale];
-	  } else if ( langOnlyLocale !== null && langOnlyLocale in textMap ) {
-		  return textMap[langOnlyLocale];
+      } else if ( langOnlyLocale !== null && langOnlyLocale in textMap ) {
+          return textMap[langOnlyLocale];
       } else if( 'default' in textMap ) {
           return textMap['default'];
       } else {
-		  return undefined;
+          return undefined;
       }
     },
    
     hasTextLocalization:function(locale, i18nToken) {
-	  return this.hasFieldLocalization(locale, i18nToken, 'text');
+      return this.hasFieldLocalization(locale, i18nToken, 'text');
     },
    
     localizeText:function(locale, i18nToken) {
-	  return this.localizeTokenField(locale, i18nToken, 'text');
+      return this.localizeTokenField(locale, i18nToken, 'text');
     },
    
     hasImageLocalization:function(locale, i18nToken) {
-	  return this.hasFieldLocalization(locale, i18nToken, 'image');
+      return this.hasFieldLocalization(locale, i18nToken, 'image');
     },
    
     hasAudioLocalization:function(locale, i18nToken) {
-	  return this.hasFieldLocalization(locale, i18nToken, 'audio');
+      return this.hasFieldLocalization(locale, i18nToken, 'audio');
     },
    
     hasVideoLocalization:function(locale, i18nToken) {
-	  return this.hasFieldLocalization(locale, i18nToken, 'video');
+      return this.hasFieldLocalization(locale, i18nToken, 'video');
     },
 
     localizeUrl:function(locale, i18nToken, fieldName, formPath) {
-	  var content = this.localizeTokenField(locale, i18nToken, fieldName);
-	  if ( content === undefined ) {
-		  return content;
-	  }
-  	  // if the Url is not prefixed by slash or http prefix, then prefix with form path
-	  if ( content.indexOf('/') === 0 || content.indexOf('http:') === 0 || content.indexOf('https:') === 0 ) {
-		return content;
-	  } else {
-		return formPath + content;
- 	  }
+      var content = this.localizeTokenField(locale, i18nToken, fieldName);
+      if ( content === undefined ) {
+          return content;
+      }
+      // if the Url is not prefixed by slash or http prefix, then prefix with form path
+      if ( content.indexOf('/') === 0 || content.indexOf('http:') === 0 || content.indexOf('https:') === 0 ) {
+        return content;
+      } else {
+        return formPath + content;
+      }
     },
 
     /**
@@ -821,12 +821,12 @@ window.odkCommon = {
 
    /**
     * Generate a globally unique id.
-	*/
+    */
    genUUID:function() {
       /*jshint bitwise: false*/
       // construct a UUID (from http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript )
       var id = "uuid:" + 
-		'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
           // NOTE: the logical OR forces the number into an integer
           var r = Math.random()*16|0;
           // and the logical OR for 'y' values forces the number to be 8, 9, a or b.
@@ -838,30 +838,30 @@ window.odkCommon = {
    },
 
    constructSurveyUri: function(tableId, formId, rowId, screenPath, elementKeyToValueMap ) {
-	   
+       
        if (!this.isString(tableId)) {
            throw 'constructSurveyUri()--tableId not a string';
        }
-	   var theFormId = null;
-	   var theRowId = null;
-	   var theScreenPath = null;
-	   if ( formId !== undefined && formId !== null ) {
-		   theFormId = formId;
-	   }
-	   if ( rowId !== undefined && rowId !== null ) {
-		   theRowId = rowId;
-	   }
-	   if ( screenPath !== undefined && screenPath !== null ) {
-		   theScreenPath = screenPath;
-	   }
-	   
-	   // stringify the key-value map before passing it to Java side...
-	   if ( elementKeyToValueMap === undefined || elementKeyToValueMap === null ) {
-		  return odkCommonIf.constructSurveyUri(tableId, theFormId, theRowId, theScreenPath, null);
-	   } else {
-		  return odkCommonIf.constructSurveyUri(tableId, theFormId, theRowId, theScreenPath, 
-				JSON.stringify(elementKeyToValueMap));
-	   }
+       var theFormId = null;
+       var theRowId = null;
+       var theScreenPath = null;
+       if ( formId !== undefined && formId !== null ) {
+           theFormId = formId;
+       }
+       if ( rowId !== undefined && rowId !== null ) {
+           theRowId = rowId;
+       }
+       if ( screenPath !== undefined && screenPath !== null ) {
+           theScreenPath = screenPath;
+       }
+       
+       // stringify the key-value map before passing it to Java side...
+       if ( elementKeyToValueMap === undefined || elementKeyToValueMap === null ) {
+          return odkCommonIf.constructSurveyUri(tableId, theFormId, theRowId, theScreenPath, null);
+       } else {
+          return odkCommonIf.constructSurveyUri(tableId, theFormId, theRowId, theScreenPath, 
+                JSON.stringify(elementKeyToValueMap));
+       }
    },
    
    /**
@@ -900,53 +900,53 @@ window.odkCommon = {
     *
     * @return one of:
     *          "IGNORE"                -- there is already a pending action
-    *          "JSONException"		   -- something is wrong with the intentObject
+    *          "JSONException"         -- something is wrong with the intentObject
     *          "OK"                    -- request issued
     *          "Application not found" -- could not find app to handle intent
     *
     * If the request has been issued, and the dispatchStruct is not null then 
-	* the javascript will be notified of the availability of a result via the
+    * the javascript will be notified of the availability of a result via the
     * registerListener callback. That callback should fetch the the results via
     *      odkCommon.viewFirstQueuedAction().
     * And they are removed from the queue via
     *      odkCommon.removeFirstQueuedAction();
     */
    doAction: function(dispatchStruct, action, intentObject) {
-	  // stringify the intent object if present
-	  var intentObjectJSONString = null;
-	  if ( intentObject !== null && intentObject !== undefined ) {
-		  intentObjectJSONString = JSON.stringify(intentObject);
-	  }
-	  // and stringify the dispatchStruct if present
-	  if ( dispatchStruct === null || dispatchStruct === undefined ) {
-		// will not notify of completion
-		return odkCommonIf.doAction(null, action, intentObjectJSONString);
-	  } else {
-		return odkCommonIf.doAction(JSON.stringify(dispatchStruct), action, intentObjectJSONString);
-	  }
+      // stringify the intent object if present
+      var intentObjectJSONString = null;
+      if ( intentObject !== null && intentObject !== undefined ) {
+          intentObjectJSONString = JSON.stringify(intentObject);
+      }
+      // and stringify the dispatchStruct if present
+      if ( dispatchStruct === null || dispatchStruct === undefined ) {
+        // will not notify of completion
+        return odkCommonIf.doAction(null, action, intentObjectJSONString);
+      } else {
+        return odkCommonIf.doAction(JSON.stringify(dispatchStruct), action, intentObjectJSONString);
+      }
    },
 
    /**
     *  Terminate the current webkit by calling:
-	*
-    *	activity.setResult(resultCode, intent);
-	*   finish();
-	*
-	*  Where the intent's extras are set to the content of the keyValueBundle
-	*
-	*  resultCode === 0 -- RESULT_CANCELLED
-	*  resultCode === -1  -- RESULT_OK
-	*  any result code >= 1 is user-defined. Unclear the level of support
-	*
-	*  This will log errors but any errors will cause a RESULT_CANCELLED 
-	*  exit. See the logs for what the error was.
+    *
+    *   activity.setResult(resultCode, intent);
+    *   finish();
+    *
+    *  Where the intent's extras are set to the content of the keyValueBundle
+    *
+    *  resultCode === 0 -- RESULT_CANCELLED
+    *  resultCode === -1  -- RESULT_OK
+    *  any result code >= 1 is user-defined. Unclear the level of support
+    *
+    *  This will log errors but any errors will cause a RESULT_CANCELLED 
+    *  exit. See the logs for what the error was.
     */
    closeWindow: function( resultCode, keyValueBundle ) {
-	   if ( keyValueBundle === null || keyValueBundle === undefined ) {
-		  odkCommonIf.closeWindow( "" + resultCode, null );
-	   } else {
-	      odkCommonIf.closeWindow( "" + resultCode, JSON.stringify(keyValueBundle) );
-	   }
+       if ( keyValueBundle === null || keyValueBundle === undefined ) {
+          odkCommonIf.closeWindow( "" + resultCode, null );
+       } else {
+          odkCommonIf.closeWindow( "" + resultCode, JSON.stringify(keyValueBundle) );
+       }
    },
    
    /**
@@ -970,11 +970,11 @@ window.odkCommon = {
     *   "#urlhash"   // if the Java code wants the Javascript to take some action without a reload
     */
    viewFirstQueuedAction: function() {
-	  var retVal = odkCommonIf.viewFirstQueuedAction();
-	  if ( retVal === null || retVal === undefined ) {
-		  return null;
-	  }
-	  return JSON.parse(retVal);
+      var retVal = odkCommonIf.viewFirstQueuedAction();
+      if ( retVal === null || retVal === undefined ) {
+          return null;
+      }
+      return JSON.parse(retVal);
    },
    /**
     * Remove the first queued action.
@@ -1002,14 +1002,14 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                 formsUri: "content://org.opendatakit.provider.forms/",
                 activeUser: 'username:badger',
                 logLevel: this._logLevel,
-				preferredLocale: 'en_US',
-				// true only if user did not override the device locale
-				usingDeviceLocale: true,
-				// info about the device locale:
-				isoCountry: 'US',
-				displayCountry: "United States",
-				isoLanguage: 'en',
-				displayLanguage: "English"
+                preferredLocale: 'en_US',
+                // true only if user did not override the device locale
+                usingDeviceLocale: true,
+                // info about the device locale:
+                isoCountry: 'US',
+                displayCountry: "United States",
+                isoLanguage: 'en',
+                displayLanguage: "English"
             };
             // Because the phone returns a String, we too are going to return a
             // string here.
@@ -1021,10 +1021,10 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
             var that = this;
             // strip off backslashes
             var cleanedStr = relativePath.replace(/\\/g, '');
-			// approx. attempt to parse the string as a URI. If it succeeds, return it as-is.
-			if ( cleanedStr.startsWith("http://") || cleanedStr.startsWith("https://") ) {
-				return cleanedStr;
-			}
+            // approx. attempt to parse the string as a URI. If it succeeds, return it as-is.
+            if ( cleanedStr.startsWith("http://") || cleanedStr.startsWith("https://") ) {
+                return cleanedStr;
+            }
             var baseUri = that._computeBaseUri();
             var result = baseUri + cleanedStr;
             return result;
@@ -1165,40 +1165,40 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
             }
             return term;
         },
-		constructSurveyUri: function(tableId, formId, rowId, screenPath, elementKeyToValueMap ) {
-			var that = this;
-			var pi = JSON.parse(that.getPlatformInfo());
-			var appName = pi.appName;
-			if ( formId === null || formId === undefined ) {
-				formId = "";
-			}
-			var uri = "content://org.opendatakit.provider.forms/" + appName + "/" + tableId + "/" + formId + "/#";
-			var continueChar = "";
-			if ( rowId !== null && rowId !== undefined ) {
-				uri += "instanceId=" + encodeURIComponent(rowId);
-				continueChar = "&";
-			}
-			if ( screenPath !== null && screenPath !== undefined ) {
-				uri += continueChar + "screenPath=" + encodeURIComponent(screenPath);
-				continueChar = "&";
-			}
-			if ( elementKeyToValueMap !== null && elementKeyToValueMap !== undefined ) {
-				var theMap = JSON.parse(elementKeyToValueMap);
-				for ( var key in theMap ) {
-					if ( theMap.hasOwnProperty(key) ) {
-						var value = theMap[key];
-						uri += continueChar + encodeURIComponent(key) + "=" + encodeURIComponent(JSON.stringify(value));
-						continueChar = "&";
-					}
-				}
-			}
-			return uri;
-		},
+        constructSurveyUri: function(tableId, formId, rowId, screenPath, elementKeyToValueMap ) {
+            var that = this;
+            var pi = JSON.parse(that.getPlatformInfo());
+            var appName = pi.appName;
+            if ( formId === null || formId === undefined ) {
+                formId = "";
+            }
+            var uri = "content://org.opendatakit.provider.forms/" + appName + "/" + tableId + "/" + formId + "/#";
+            var continueChar = "";
+            if ( rowId !== null && rowId !== undefined ) {
+                uri += "instanceId=" + encodeURIComponent(rowId);
+                continueChar = "&";
+            }
+            if ( screenPath !== null && screenPath !== undefined ) {
+                uri += continueChar + "screenPath=" + encodeURIComponent(screenPath);
+                continueChar = "&";
+            }
+            if ( elementKeyToValueMap !== null && elementKeyToValueMap !== undefined ) {
+                var theMap = JSON.parse(elementKeyToValueMap);
+                for ( var key in theMap ) {
+                    if ( theMap.hasOwnProperty(key) ) {
+                        var value = theMap[key];
+                        uri += continueChar + encodeURIComponent(key) + "=" + encodeURIComponent(JSON.stringify(value));
+                        continueChar = "&";
+                    }
+                }
+            }
+            return uri;
+        },
         doAction: function(dispatchStructAsJSONstring, action, jsonObj ) {
             var that = this;
             var lat, lng, alt, acc;
 
-			var dispatchStruct = (dispatchStructAsJSONstring !== null &&
+            var dispatchStruct = (dispatchStructAsJSONstring !== null &&
                                   dispatchStructAsJSONstring !== undefined ) ? JSON.parse(dispatchStructAsJSONstring) : null;
             var value;
             that.log("D","odkCommon: DO: doAction(" + dispatchStructAsJSONstring + ", " + action + ", ...)");
@@ -1380,15 +1380,15 @@ if ( window.odkCommonIf === undefined || window.odkCommonIf === null ) {
                 return "OK";
             }
         },
-		closeWindow: function( resultCode, jsonResult ) {
-			// TODO: return resultCode and result when there is a parent window
-			// stub just closes window and doesn't return value.
-		    if ( window.parent === window ) { 
+        closeWindow: function( resultCode, jsonResult ) {
+            // TODO: return resultCode and result when there is a parent window
+            // stub just closes window and doesn't return value.
+            if ( window.parent === window ) { 
                 window.close(); 
             } else { 
                 window.parent.closeAndPopPage(); 
             } 
-		},
+        },
         /**
          * Return the first queued action without removing it.
          */

--- a/app/system/js/odkData.js
+++ b/app/system/js/odkData.js
@@ -6,12 +6,45 @@
  
  (function() {
 'use strict';
+/* globals odkCommon */
 
 window.odkData = {
     _requestMap: [],
-//     _tableKVSCacheMap: [],
     _transactionId: 0,
     _callbackId: 0,
+    _tableMetadataCache: {},
+    
+    _getTableMetadata: function(tableId) {
+        var that = this;
+        if ( tableId === null || tableId === undefined ) {
+            return null;
+        }
+        var tableEntry = that._tableMetadataCache[tableId];
+        if ( tableEntry === undefined || tableEntry === null ) {
+            return null;
+        }
+        return tableEntry;
+    },
+
+    _getTableMetadataRevision: function(tableId) {
+        var that = this;
+        if ( tableId === null || tableId === undefined ) {
+            return null;
+        }
+        var tableEntry = that._tableMetadataCache[tableId];
+        if ( tableEntry === undefined || tableEntry === null ) {
+            return null;
+        }
+        return tableEntry.metaDataRev;
+    },
+
+    _putTableMetadata: function(tableId, metadata) {
+        var that = this;
+        if ( tableId === null || tableId === undefined ) {
+            return;
+        }
+        that._tableMetadataCache[tableId] = metadata;
+    },
     
     getOdkDataIf: function() {
         return window.odkDataIf;
@@ -66,12 +99,15 @@ window.odkData = {
         var that = this;
 
         var req = that.queueRequest('query', successCallbackFn, failureCallbackFn);
+        var stringLimit = limit == null ? null : limit.toString();
+        var stringOffset = offset == null ? null : offset.toString();
 
         // need to JSON.stringify bind parameters so we can pass integer, numeric and boolean parameters as-is.
         var sqlBindParamsJSON = (sqlBindParams === null || sqlBindParams === undefined) ? null : 
                 JSON.stringify(sqlBindParams);
         that.getOdkDataIf().query(tableId, whereClause, sqlBindParamsJSON, groupBy, 
-            having, orderByElementKey, orderByDirection, limit, offset, includeKVS, req._callbackId);
+            having, orderByElementKey, orderByDirection, stringLimit, stringOffset, includeKVS, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     arbitraryQuery: function(tableId, sqlCommand, sqlBindParams, limit, offset, successCallbackFn, failureCallbackFn) {
@@ -84,7 +120,8 @@ window.odkData = {
         // need to JSON.stringify bind parameters so we can pass integer, numeric and boolean parameters as-is.
         var sqlBindParamsJSON = (sqlBindParams === null || sqlBindParams === undefined) ? null : 
                 JSON.stringify(sqlBindParams);
-        that.getOdkDataIf().arbitraryQuery(tableId, sqlCommand, sqlBindParamsJSON, stringLimit, stringOffset, req._callbackId);
+        that.getOdkDataIf().arbitraryQuery(tableId, sqlCommand, sqlBindParamsJSON, stringLimit, stringOffset, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     getRows: function(tableId, rowId, successCallbackFn, failureCallbackFn) {
@@ -92,7 +129,8 @@ window.odkData = {
 
         var req = that.queueRequest('getRows', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().getRows(tableId, rowId, req._callbackId);
+        that.getOdkDataIf().getRows(tableId, rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     getMostRecentRow: function(tableId, rowId, successCallbackFn, failureCallbackFn) {
@@ -100,7 +138,8 @@ window.odkData = {
 
         var req = that.queueRequest('getMostRecentRow', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().getMostRecentRow(tableId, rowId, req._callbackId);
+        that.getOdkDataIf().getMostRecentRow(tableId, rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     changeAccessFilterOfRow: function(tableId, defaultAccess, rowOwner, groupReadOnly, groupModify, 
@@ -109,8 +148,9 @@ window.odkData = {
 
         var req = that.queueRequest('changeAccessFilterOfRow', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().changeAccessFilterOfRow(tableId, defaultAccess, rowOwner, groupReadOnly, groupModify,
-        groupPrivileged, rowId, req._callbackId);
+        that.getOdkDataIf().changeAccessFilterOfRow(tableId, defaultAccess, rowOwner, 
+            groupReadOnly, groupModify, groupPrivileged, rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
     
     updateRow: function(tableId, columnNameValueMap, rowId, successCallbackFn, failureCallbackFn) {
@@ -118,7 +158,8 @@ window.odkData = {
 
         var req = that.queueRequest('updateRow', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().updateRow(tableId, JSON.stringify(columnNameValueMap), rowId, req._callbackId);
+        that.getOdkDataIf().updateRow(tableId, JSON.stringify(columnNameValueMap), rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     deleteRow: function(tableId, columnNameValueMap, rowId, successCallbackFn, failureCallbackFn) {
@@ -126,7 +167,8 @@ window.odkData = {
 
         var req = that.queueRequest('deleteRow', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().deleteRow(tableId, JSON.stringify(columnNameValueMap), rowId, req._callbackId);
+        that.getOdkDataIf().deleteRow(tableId, JSON.stringify(columnNameValueMap), rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     addRow: function(tableId, columnNameValueMap, rowId, successCallbackFn, failureCallbackFn) {
@@ -134,7 +176,8 @@ window.odkData = {
 
         var req = that.queueRequest('addRow', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().addRow(tableId, JSON.stringify(columnNameValueMap), rowId, req._callbackId);
+        that.getOdkDataIf().addRow(tableId, JSON.stringify(columnNameValueMap), rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     addCheckpoint: function(tableId, columnNameValueMap, rowId, successCallbackFn, failureCallbackFn) {
@@ -142,7 +185,8 @@ window.odkData = {
 
         var req = that.queueRequest('addCheckpoint', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().addCheckpoint(tableId, JSON.stringify(columnNameValueMap), rowId, req._callbackId);
+        that.getOdkDataIf().addCheckpoint(tableId, JSON.stringify(columnNameValueMap), rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     saveCheckpointAsIncomplete: function(tableId, columnNameValueMap, rowId, successCallbackFn, failureCallbackFn) {
@@ -150,7 +194,8 @@ window.odkData = {
 
         var req = that.queueRequest('saveCheckpointAsIncomplete', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().saveCheckpointAsIncomplete(tableId, JSON.stringify(columnNameValueMap), rowId, req._callbackId); 
+        that.getOdkDataIf().saveCheckpointAsIncomplete(tableId, JSON.stringify(columnNameValueMap), rowId,
+            that._getTableMetadataRevision(tableId), req._callbackId); 
     },
 
     saveCheckpointAsComplete: function(tableId, columnNameValueMap, rowId, successCallbackFn, failureCallbackFn) {
@@ -158,7 +203,8 @@ window.odkData = {
 
         var req = that.queueRequest('saveCheckpointAsComplete', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().saveCheckpointAsComplete(tableId, JSON.stringify(columnNameValueMap), rowId, req._callbackId);
+        that.getOdkDataIf().saveCheckpointAsComplete(tableId, JSON.stringify(columnNameValueMap), rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     deleteAllCheckpoints: function(tableId, rowId, successCallbackFn, failureCallbackFn) {
@@ -166,7 +212,8 @@ window.odkData = {
 
         var req = that.queueRequest('deleteLastCheckpoint', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().deleteAllCheckpoints(tableId, rowId, req._callbackId);
+        that.getOdkDataIf().deleteAllCheckpoints(tableId, rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     deleteLastCheckpoint: function(tableId, rowId, successCallbackFn, failureCallbackFn) {
@@ -174,7 +221,8 @@ window.odkData = {
 
         var req = that.queueRequest('deleteLastCheckpoint', successCallbackFn, failureCallbackFn);
 
-        that.getOdkDataIf().deleteLastCheckpoint(tableId, rowId, req._callbackId);
+        that.getOdkDataIf().deleteLastCheckpoint(tableId, rowId, 
+            that._getTableMetadataRevision(tableId), req._callbackId);
     },
 
     queueRequest: function (type, successCallbackFn, failureCallbackFn) {
@@ -219,7 +267,7 @@ window.odkData = {
                 var trxn = that._requestMap[i];
                 that._requestMap.splice(i, 1);
                 if (errorMsg !== null && errorMsg !== undefined) {
-                    console.log('odkData invokeCallbackFn error - requestType: ' + trxn._requestType + ' callbackId: ' + trxn._callbackId +
+                    odkCommon.log('E','odkData invokeCallbackFn error - requestType: ' + trxn._requestType + ' callbackId: ' + trxn._callbackId +
                     ' error: ' + errorMsg);
                     if (errorMsg.indexOf("org.opendatakit.exception.ActionNotAuthorize") === 0) {
                         document.body.innerHTML = "<h1>Access denied</h1>You do have access to perform this action. Please log in or check your credentials."; // TODO: TEMPORARY
@@ -228,7 +276,7 @@ window.odkData = {
                         (trxn._failureCbFn)(errorMsg);
                     }
                 } else {
-                    console.log('odkData invokeCallbackFn success - requestType: ' + trxn._requestType + ' callbackId: ' + trxn._callbackId);
+                    odkCommon.log('D','odkData invokeCallbackFn success - requestType: ' + trxn._requestType + ' callbackId: ' + trxn._callbackId);
                     
                     // Need to update the cached KVS if we have a query request type
 //                     if (trxn._requestType === 'query') {
@@ -246,63 +294,9 @@ window.odkData = {
         }
         
         if (!found) {
-            console.log('odkData invokeCallbackFn - no callback found for callbackId: ' + cbId);
+            odkCommon.log('E','odkData invokeCallbackFn - no callback found for callbackId: ' + cbId);
         }
     },
-    
-//     updateCachedMetadataForTableId: function(jsonResult, cbId) {
-//         var that = this;
-//         // If the metadata does not contain the tableId log to console
-//         if (jsonResult.metadata.tableId === null || jsonResult.metadata.tableId === undefined) {
-//             throw new Error('table id not found in the metadata for callback id: ' + cbId);
-//         }
-// 
-//         // If there is metadata in this response for a table id that
-//         // is not cached, cache it now
-//         var tableKVSCache = null;
-//         tableKVSCache = that.getCachedMetadataForTableId(jsonResult.metadata.tableId);
-//         
-//         if (tableKVSCache === null) {
-//             if (jsonResult.metadata.keyValueStoreList !== null && jsonResult.metadata.keyValueStoreList !== undefined) {
-//                 odkCommon.log('D','odkData:invokeCallbackFn: adding KVS for tableId: ' + jsonResult.metadata.tableId);
-//                 tableKVSCache = {};
-//                 tableKVSCache.tableId = jsonResult.metadata.tableId;
-//                 tableKVSCache.keyValueStoreList = jsonResult.metadata.keyValueStoreList; 
-//                 that._tableKVSCacheMap.push(tableKVSCache);
-//             } else {
-//                 throw new Error('odkData: tableKVSCache does not contain metadata for table id: ' + jsonResult.metadata.tableId + ' but should');   
-//             }
-//         }
-// 
-//         // At this point, we should always have metadata for any table
-//         // that has been queried before 
-//         if (jsonResult.metadata.keyValueStoreList === null || jsonResult.metadata.keyValueStoreList === undefined) {
-//             jsonResult.metadata.keyValueStoreList = tableKVSCache;
-//         }
-//     },
-// 
-//     getCachedMetadataForTableId : function(tableId) {
-//         var that = this;
-//         var tableKVSMetadata = null;
-//         for (var i = 0; i < that._tableKVSCacheMap.length; i++) {
-//             if (that._tableKVSCacheMap[i].tableId === tableId) {
-//                 tableKVSMetadata = that._tableKVSCacheMap[i].keyValueStoreList;
-//                 odkCommon.log('D','odkData:getCachedMetadataForTableId: found KVS for tableId: ' + tableId);
-//                 break;
-//             }
-//         }
-//         return tableKVSMetadata;
-//     },
-// 
-//     needToIncludeKVSInQuery : function(tableId) {
-//         var that = this;
-//         var includeKVS = true;
-//         var cachedKVS = that.getCachedMetadataForTableId(tableId);
-//         if (cachedKVS !== null && cachedKVS !== undefined) {
-//             includeKVS = false;
-//         }
-//         return includeKVS;
-//     },
 
     responseAvailable: function() {
         var that = this;
@@ -344,8 +338,6 @@ window.odkData = {
         // This is the object that will wrap up the result from an async query.
         var pub = {
             resultObj : null,
-            // holds keyValueList re-imagined as a map.
-            kvMap : {},
 
             _isNotEmptyObject: function(obj) {
                 // !$.isEmptyObject(obj)
@@ -358,18 +350,21 @@ window.odkData = {
                 return false;
             },
             
-            /**
-             * This function is used to set the 
-             * backing data object that all of the 
-             * member functions operate on
-             *
-             * jsonObj should be a JSON object.
-             */
-            setBackingObject:function(jsonObj) {
+            _expandMetadataCache: function(cachedMetadata) {
                 var that = this;
-                
-                that.resultObj = jsonObj;
-                
+
+                // working variables for misc. data structure iteration             
+                var f;
+                var i;
+
+                // working variables for dataTableModel processing
+                var defElement;
+
+                // working variables for choiceListMap procesing
+                var theList;
+                var theMap;
+                var choiceObject;
+
                 // the dataTableModel returned from the Java layer is roughly a JSON schema and 
                 // does not have all of the persisted elementKey entries at the top level.
                 // i.e., if they are in an object type (which is not persisted), the nested elements 
@@ -377,12 +372,9 @@ window.odkData = {
                 // nesting within the object). Traverse the dataTableModel searching for the non-retained
                 // elements, and if they are object types, collect their properties, appending them to 
                 // the top-level list and recursively traversing them.
-                var fullDataTableModel = that.resultObj.metadata.dataTableModel;
+                var fullDataTableModel = cachedMetadata.dataTableModel;
                 // content to add to the fullDataTableModel
                 var additionalDataTableModel = {};
-                
-                var f;
-                var defElement;
 
                 // working model fragment
                 var dataTableModel;
@@ -428,36 +420,123 @@ window.odkData = {
                         fullDataTableModel[f] = additionalDataTableModel[f];
                     }
                 }
-
-                // and build the kvMap
-                if (that.resultObj.metadata.keyValueStoreList === null || 
-                    that.resultObj.metadata.keyValueStoreList === undefined) {
-                    return;
+                
+                cachedMetadata._parsedChoiceListMap = {};
+                cachedMetadata._parsedChoiceListValueMap = {};
+                if ( cachedMetadata.choiceListMap !== null &&
+                     cachedMetadata.choiceListMap !== undefined ) {
+                    // process the choiceListMap into _parsedChoiceListMap and _parsedChoiceListValueMap
+                    //
+                    // The Java side returns a choiceListMap map of choice_list_id => JSON string
+                    // 1. parse the JSON string -- yielding the ordered array of choice objects
+                    //    that identify the choice value and the display translation for that value.
+                    //    Store this in _parsedChoiceListMap (choice_list_id => parsed list).
+                    // 2. interate over the list producing a map of choice values to choice objects.
+                    //    Store this in _parsedChoiceListValueMap 
+                    //         (choice_list_id => {map of choice value => choice object}).
+                    //
+                    for ( f in cachedMetadata.choiceListMap ) {
+                        if ( cachedMetadata.choiceListMap.hasOwnProperty(f) ) {
+                            theList = JSON.parse(cachedMetadata.choiceListMap[f]);
+                            theMap = {};
+                            for ( i = 0 ; i < theList.length ; ++i ) {
+                                choiceObject = theList[i];
+                                theMap[choiceObject.data_value] = choiceObject;
+                            }
+                            cachedMetadata._parsedChoiceListMap[f] = theList;
+                            cachedMetadata._parsedChoiceListValueMap[f] = theMap;
+                        }
+                    }
                 }
 
-                var kvsLen = that.resultObj.metadata.keyValueStoreList.length;
+                // build the kvMap
+                // The keyValueStoreList is traversed and transformed into the kvMap.
+                //    cachedMetadata.kvMap[partition][aspect][key] = value
+                //
+                // If partition === 'Column' && key === 'displayChoicesList' then
+                // add two new keys, '_displayChoicesList' and '_displayChoicesMap'
+                // tying back to the structures maintained in 
+                //    cachedMetadata._parsedChoiceListMap
+                //    cachedMetadata._parsedChoiceListValueMap
+                //
+                cachedMetadata.kvMap = {};
+                if (cachedMetadata.keyValueStoreList === null || 
+                    cachedMetadata.keyValueStoreList === undefined) {
+                    return;
+                }
+                var kvsLen = cachedMetadata.keyValueStoreList.length;
 
                 odkCommon.log('W',"odkData/setBackingObject: processing keyValueStoreList of size " + kvsLen);
-
-                // the keyValueStoreList is not very efficient for accessing values.
-                // Convert this into a Javascript map stored in that.kvMap so we can access it as:
-                //      that.kvMap[partition][aspect][key]
-                // And, for partition === 'Column' && key === 'displayChoicesList', add 
-                // two new synthesized keys:
-                //      _displayChoicesList -- JSON.parse of 'displayChoicesList' value (array)
-                //      _displayChoicesMap -- conversion of this list into a map indexed by data_value.
-                //
-                for (var i = 0; i < kvsLen; i++) {
-                    var kvs = that.resultObj.metadata.keyValueStoreList[i];
-                    if ( !(that.kvMap.hasOwnProperty(kvs.partition)) ) {
-                        that.kvMap[kvs.partition] = {};
+                for (i = 0; i < kvsLen; i++) {
+                    var kvs = cachedMetadata.keyValueStoreList[i];
+                    if ( !(cachedMetadata.kvMap.hasOwnProperty(kvs.partition)) ) {
+                        cachedMetadata.kvMap[kvs.partition] = {};
                     }
-                    var partition = that.kvMap[kvs.partition];
+                    var partition = cachedMetadata.kvMap[kvs.partition];
                     if ( !(partition.hasOwnProperty(kvs.aspect)) ) {
                         partition[kvs.aspect] = {};
                     }
                     var aspect = partition[kvs.aspect];
                     aspect[kvs.key] = kvs;
+                    // Transform the choice list into a list.  
+                    // Use _displayChoicesList as the key. 
+                    // Transform the choice list into a map.
+                    // Use _displayChoicesMap as the key.                   
+                    if ( kvs.partition === "Column" && 
+                         kvs.key === "displayChoicesList" && 
+                         kvs.value !== null ) { 
+ 
+                        // save the parsed content 
+                        var choiceList = cachedMetadata._parsedChoiceListMap[kvs.value]; 
+                        aspect["_displayChoicesList"] = choiceList; 
+ 
+                        // create a map of choiceList data_value to object 
+                        var choiceMap = cachedMetadata._parsedChoiceListValueMap[kvs.value]; 
+                        aspect["_displayChoicesMap"] = choiceMap; 
+                    }
+                }
+            },
+            
+            /**
+             * This function is used to set the 
+             * backing data object that all of the 
+             * member functions operate on
+             *
+             * jsonObj should be a JSON object.
+             */
+            setBackingObject:function(jsonObj) {
+                var that = this;
+                
+                that.resultObj = jsonObj;
+                
+                var metadataCache;
+                var tableId = that.resultObj.metadata.tableId;
+                
+                // update odkData metadata cache if we receive an update
+                if ( that.resultObj.metadata !== null &&
+                     that.resultObj.metadata !== undefined &&
+                     that.resultObj.metadata.hasOwnProperty('cachedMetadata') ) {
+                    odkCommon.log('W','cachedMetadata present in ' + tableId + ' response');
+                    // we have an update for the metadata cache
+                    metadataCache = that.resultObj.metadata.cachedMetadata;
+                    // expand the returned metadata so that we can efficiently use it.
+                    that._expandMetadataCache(metadataCache);
+                    // cache it
+                    window.odkData._putTableMetadata(tableId, metadataCache);
+                    // and remove the cachedMetadata
+                    delete that.resultObj.metadata.cachedMetadata;
+                }
+                
+                // fetch the metadata cache
+                metadataCache = window.odkData._getTableMetadata(tableId);
+                if ( metadataCache !== null && metadataCache !== undefined ) {
+                    // apply the metadata cache
+                    var f;
+                    for ( f in metadataCache ) {
+                        if ( metadataCache.hasOwnProperty(f) ) {
+                            that.resultObj.metadata[f] = metadataCache[f];
+                        }
+                    }
                 }
             },
 
@@ -933,7 +1012,7 @@ window.odkData = {
                     return retVal;
                 }
 
-                var ref = that.kvMap['Column'];
+                var ref = that.resultObj.metadata.kvMap['Column'];
                 if ( ref === null || ref === undefined ) {
                     return retVal;
                 }
@@ -967,7 +1046,7 @@ window.odkData = {
                     return retVal;
                 }
 
-                var ref = that.kvMap['Table'];
+                var ref = that.resultObj.metadata.kvMap['Table'];
                 if ( ref === null || ref === undefined ) {
                     return retVal;
                 }
@@ -1000,7 +1079,7 @@ window.odkData = {
                     return retVal;
                 }
 
-                var ref = that.kvMap['Table'];
+                var ref = that.resultObj.metadata.kvMap['Table'];
                 if ( ref === null || ref === undefined ) {
                     return retVal;
                 }
@@ -1034,7 +1113,96 @@ window.odkData = {
                 return that.resultObj.metadata.canCreateRow;
         
             },
-
+            
+            // 
+            // Retrieves the list of choices for the given elementPath 
+            // or null if there is not a list of choices in the table 
+            // properties for this column. This is the already-JSON-parsed 
+            // value. The list order is the order in which these choices 
+            // should be presented in the selection-list. 
+            getColumnChoicesList:function(elementPath) { 
+                var that = this; 
+                var retVal = null; 
+ 
+                if (that.resultObj === null || that.resultObj === undefined) { 
+                    return retVal; 
+                } 
+ 
+                if (that.resultObj.metadata === null || that.resultObj.metadata === undefined) { 
+                    return retVal; 
+                } 
+ 
+                if (that.resultObj.metadata.keyValueStoreList === null ||  
+                    that.resultObj.metadata.keyValueStoreList === undefined) { 
+                    return retVal; 
+                } 
+ 
+                var ref = that.resultObj.metadata.kvMap['Column']; 
+                if ( ref === null || ref === undefined ) { 
+                    return retVal; 
+                } 
+                var elementKey = that.getElementKey(elementPath); 
+                ref = ref[elementKey]; 
+                if ( ref === null || ref === undefined ) { 
+                    return retVal; 
+                } 
+                // NOTE: this is synthesized within setBackingObject() 
+                ref = ref['_displayChoicesList']; 
+                if ( ref === null || ref === undefined ) { 
+                    return retVal; 
+                } 
+                retVal = ref; 
+                return retVal; 
+            }, 
+ 
+            // 
+            // Effectively retrieves the object for the given data_value from  
+            // the displayChoicesList for the given elementPath. Equivalent to  
+            // searching through the '_displayChoicesList' value for the object 
+            // where object.data_value === choiceDataValue. 
+            // 
+            // The caller can then access the .display.title for the  
+            // text translation of this object or any custom property  
+            // associated with this choice data value (via the tableId form). 
+            getColumnChoiceDataValueObject:function(elementPath, choiceDataValue) { 
+                var that = this; 
+                var retVal = null; 
+ 
+                if (that.resultObj === null || that.resultObj === undefined) { 
+                    return retVal; 
+                } 
+ 
+                if (that.resultObj.metadata === null || that.resultObj.metadata === undefined) { 
+                    return retVal; 
+                } 
+ 
+                if (that.resultObj.metadata.keyValueStoreList === null ||  
+                    that.resultObj.metadata.keyValueStoreList === undefined) { 
+                    return retVal; 
+                } 
+ 
+                var ref = that.resultObj.metadata.kvMap['Column']; 
+                if ( ref === null || ref === undefined ) { 
+                    return retVal; 
+                } 
+                var elementKey = that.getElementKey(elementPath); 
+                ref = ref[elementKey]; 
+                if ( ref === null || ref === undefined ) { 
+                    return retVal; 
+                } 
+                // NOTE: this is synthesized within setBackingObject() 
+                ref = ref['_displayChoicesMap']; 
+                if ( ref === null || ref === undefined ) { 
+                    return retVal; 
+                } 
+                ref = ref[choiceDataValue]; 
+                if ( ref === null || ref === undefined ) { 
+                    return retVal; 
+                } 
+                retVal = ref; 
+                return retVal; 
+            }, 
+ 
             // may need to get the raw metadata content to get access to some of the content.
             getMetadata:function() {
                 var that = this;

--- a/app/system/survey/js/controller.js
+++ b/app/system/survey/js/controller.js
@@ -1271,8 +1271,6 @@ return {
         var terminateCtxt = $.extend({},baseCtxt,{success: function() {
                 baseCtxt.log('I', "controller.registerQueuedActionAvailableListener.terminateCtxt success");
                 if (generation === that.registrationGeneration) {
-                    // only alert that the framework is valid if the generation is current
-                    odkSurveyStateManagement.frameworkHasLoaded(refId, true );
                     var fn = that.createCallbackQueuedActionAvailableListener(generation);
                     odkCommon.registerListener(fn);
                     (fn)();
@@ -1281,8 +1279,6 @@ return {
             }, failure: function(m) {
                 baseCtxt.log('I', "controller.registerQueuedActionAvailableListener.terminateCtxt failure");
                 if (generation === that.registrationGeneration) {
-                    // only alert that the framework is valid if the generation is current
-                    odkSurveyStateManagement.frameworkHasLoaded(refId, false );
                     var fn = that.createCallbackQueuedActionAvailableListener(generation);
                     odkCommon.registerListener(fn);
                     (fn)();

--- a/app/system/survey/js/database.js
+++ b/app/system/survey/js/database.js
@@ -43,7 +43,6 @@ return {
             tlo.metadata.lastSyncTime = -1;
             tlo.metadata.dataTableModel = formDef.specification.dataTableModel;
             tlo.metadata.elementKeyMap = {};
-            tlo.metadata.orderedColumns = {};
             tlo.metadata.keyValueStoreList = [];
             var entry;
             var kvsEntry;

--- a/app/system/survey/js/database.js
+++ b/app/system/survey/js/database.js
@@ -49,16 +49,16 @@ return {
             var kvsEntry;
             var value;
             for ( entry in formDef.specification.properties ) {
-				if ( formDef.specification.properties.hasOwnProperty(entry) ) {
-					kvsEntry = {};
-					kvsEntry.partition = entry._partition;
-					kvsEntry.aspect = entry._aspect;
-					kvsEntry.key = entry._key;
-					kvsEntry.type = entry._type;
-					value = entry._value;
-					kvsEntry.value = databaseUtils.fromKVStoreToElementType(kvsEntry.type, value);
-					tlo.metadata.keyValueStoreList.push(kvsEntry);
-				}
+                if ( formDef.specification.properties.hasOwnProperty(entry) ) {
+                    kvsEntry = {};
+                    kvsEntry.partition = entry._partition;
+                    kvsEntry.aspect = entry._aspect;
+                    kvsEntry.key = entry._key;
+                    kvsEntry.type = entry._type;
+                    value = entry._value;
+                    kvsEntry.value = databaseUtils.fromKVStoreToElementType(kvsEntry.type, value);
+                    tlo.metadata.keyValueStoreList.push(kvsEntry);
+                }
             }
             ctxt.success(tlo);
         } else {
@@ -106,17 +106,17 @@ return {
             // these are already in the odkData interface format.
             // we need to parse them back into their representation formats.
             for (dbKey in that.pendingChanges ) {
-				if ( that.pendingChanges.hasOwnProperty(dbKey) ) {
-					// for logging...
-					keys.push(dbKey);
-					// get the type and the change entry
-					jsonType = model.dataTableModel[dbKey];
-					pendingChangeEntry = that.pendingChanges[dbKey];
-					if ( pendingChangeEntry !== undefined && pendingChangeEntry !== null ) {
-						// construct the data-update entry
-						updates[dbKey] = { elementPath: pendingChangeEntry.elementPath, value: pendingChangeEntry.value };
-					}
-				}
+                if ( that.pendingChanges.hasOwnProperty(dbKey) ) {
+                    // for logging...
+                    keys.push(dbKey);
+                    // get the type and the change entry
+                    jsonType = model.dataTableModel[dbKey];
+                    pendingChangeEntry = that.pendingChanges[dbKey];
+                    if ( pendingChangeEntry !== undefined && pendingChangeEntry !== null ) {
+                        // construct the data-update entry
+                        updates[dbKey] = { elementPath: pendingChangeEntry.elementPath, value: pendingChangeEntry.value };
+                    }
+                }
             }
             // apply the updates
             databaseUtils.reconstructModelDataFromElementPathValueUpdates(model, updates);
@@ -147,18 +147,18 @@ return {
 
             // read any session variables into updates
             for ( dbKey in model.dataTableModel ) {
-				if ( model.dataTableModel.hasOwnProperty(dbKey) ) {
-					jsonType = model.dataTableModel[dbKey];
-					if ( databaseUtils.isUnitOfRetention(jsonType) ) {
-						elementPath = jsonType.elementPath;
-						if ( jsonType.isSessionVariable ) {
-							jsValue = odkCommon.getSessionVariable(elementPath );
-							value = (jsValue === null || jsValue === undefined) ? null :
-									databaseUtils.fromSerializationToElementType(jsonType, jsValue, true);
-							updates[dbKey] = { elementPath: elementPath, value: value };
-						}
-					}
-				}
+                if ( model.dataTableModel.hasOwnProperty(dbKey) ) {
+                    jsonType = model.dataTableModel[dbKey];
+                    if ( databaseUtils.isUnitOfRetention(jsonType) ) {
+                        elementPath = jsonType.elementPath;
+                        if ( jsonType.isSessionVariable ) {
+                            jsValue = odkCommon.getSessionVariable(elementPath );
+                            value = (jsValue === null || jsValue === undefined) ? null :
+                                    databaseUtils.fromSerializationToElementType(jsonType, jsValue, true);
+                            updates[dbKey] = { elementPath: elementPath, value: value };
+                        }
+                    }
+                }
             }
 
             // reconstruct the data and instanceMetadata fields.
@@ -180,43 +180,43 @@ return {
         // read data from the row and
         // read any session variables into model.data
         for ( dbKey in model.dataTableModel ) {
-			if ( model.dataTableModel.hasOwnProperty(dbKey) ) {
-				jsonType = model.dataTableModel[dbKey];
-				if ( databaseUtils.isUnitOfRetention(jsonType) ) {
-					elementPath = jsonType.elementPath;
-					if ( jsonType.isSessionVariable ) {
-						jsValue = odkCommon.getSessionVariable(elementPath );
-						value = (jsValue === null || jsValue === undefined) ? null :
-								databaseUtils.fromSerializationToElementType(jsonType, jsValue, true);
-					} else {
-						value = reqData.getData(0, dbKey);
-						// mainly to convert datetime and time values...
-						value = databaseUtils.fromOdkDataInterfaceToElementType(jsonType, value, true);
-					}
-					updates[dbKey] = { elementPath: elementPath, value: value };
-				}
-			}
+            if ( model.dataTableModel.hasOwnProperty(dbKey) ) {
+                jsonType = model.dataTableModel[dbKey];
+                if ( databaseUtils.isUnitOfRetention(jsonType) ) {
+                    elementPath = jsonType.elementPath;
+                    if ( jsonType.isSessionVariable ) {
+                        jsValue = odkCommon.getSessionVariable(elementPath );
+                        value = (jsValue === null || jsValue === undefined) ? null :
+                                databaseUtils.fromSerializationToElementType(jsonType, jsValue, true);
+                    } else {
+                        value = reqData.getData(0, dbKey);
+                        // mainly to convert datetime and time values...
+                        value = databaseUtils.fromOdkDataInterfaceToElementType(jsonType, value, true);
+                    }
+                    updates[dbKey] = { elementPath: elementPath, value: value };
+                }
+            }
         }
 
         // if the pendingChanges are reflected in the updates[].value, then remove them
         var pendingChangeEntry, currentEntry;
         var keysToRemove = [];
         for (dbKey in that.pendingChanges ) {
-			if ( that.pendingChanges.hasOwnProperty(dbKey) ) {
-				jsonType = model.dataTableModel[dbKey];
-				currentEntry = updates[dbKey];
-				pendingChangeEntry = that.pendingChanges[dbKey];
-				if ( currentEntry !== undefined && currentEntry !== null &&
-					 pendingChangeEntry !== undefined && pendingChangeEntry !== null ) {
-					// the value in the values array may not be the correct data type -- force it to be converted
-					value = pendingChangeEntry.value;
-					value = databaseUtils.toOdkDataInterfaceFromElementType(jsonType, value, true);
-					value = databaseUtils.fromOdkDataInterfaceToElementType(jsonType, value, true);
-					if ( JSON.stringify(currentEntry.value) === JSON.stringify(value) ) {
-						keysToRemove.push(dbKey);
-					}
-				}
-			}
+            if ( that.pendingChanges.hasOwnProperty(dbKey) ) {
+                jsonType = model.dataTableModel[dbKey];
+                currentEntry = updates[dbKey];
+                pendingChangeEntry = that.pendingChanges[dbKey];
+                if ( currentEntry !== undefined && currentEntry !== null &&
+                     pendingChangeEntry !== undefined && pendingChangeEntry !== null ) {
+                    // the value in the values array may not be the correct data type -- force it to be converted
+                    value = pendingChangeEntry.value;
+                    value = databaseUtils.toOdkDataInterfaceFromElementType(jsonType, value, true);
+                    value = databaseUtils.fromOdkDataInterfaceToElementType(jsonType, value, true);
+                    if ( JSON.stringify(currentEntry.value) === JSON.stringify(value) ) {
+                        keysToRemove.push(dbKey);
+                    }
+                }
+            }
         }
 
         // do the removal outside the loop so that the for() iterator cannot be affected.
@@ -250,7 +250,7 @@ return {
                 }
             },
             function(errorMsg) {
-				that._process_odkData_error(ctxt, errorMsg);
+                that._process_odkData_error(ctxt, errorMsg);
             });
     },
 
@@ -284,28 +284,28 @@ return {
             // NOTE: setModelDataValueDeferredChange will not accept any data table changes if instanceId is null or undefined
             // apply the model defaults.
             for ( elementPath in model.dataTableModel ) {
-				if ( model.dataTableModel.hasOwnProperty(elementPath) ) {
-					jsonType = model.dataTableModel[elementPath];
-					if ( jsonType['default'] !== undefined && jsonType['default'] !== null ) {
-						// otherwise, use the default for the session variable
-						value = jsonType['default'];
-						databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, value, accumulatedChanges, true);
-					}
-				}
+                if ( model.dataTableModel.hasOwnProperty(elementPath) ) {
+                    jsonType = model.dataTableModel[elementPath];
+                    if ( jsonType['default'] !== undefined && jsonType['default'] !== null ) {
+                        // otherwise, use the default for the session variable
+                        value = jsonType['default'];
+                        databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, value, accumulatedChanges, true);
+                    }
+                }
             }
             // NOTE: setModelDataValueDeferredChange will not accept any data table changes if instanceId is null or undefined
             // and now apply any changes from the instanceMetadataKeyValueMap
             // NOTE: this will have been cleared at the top of the method if sameInstance is true.
             for ( elementPath in instanceMetadataKeyValueMap ) {
-				if ( instanceMetadataKeyValueMap.hasOwnProperty(elementPath) ) {
-					if ( instanceMetadataKeyValueMap[elementPath] === null ) {
-						value = null;
-					} else {
-						jsonType = model.dataTableModel[elementPath];
-						value = databaseUtils.fromSerializationToElementType(jsonType, instanceMetadataKeyValueMap[elementPath], true);
-					}
-					databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, value, accumulatedChanges, true);
-				}
+                if ( instanceMetadataKeyValueMap.hasOwnProperty(elementPath) ) {
+                    if ( instanceMetadataKeyValueMap[elementPath] === null ) {
+                        value = null;
+                    } else {
+                        jsonType = model.dataTableModel[elementPath];
+                        value = databaseUtils.fromSerializationToElementType(jsonType, instanceMetadataKeyValueMap[elementPath], true);
+                    }
+                    databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, value, accumulatedChanges, true);
+                }
             }
             // and discard the accumulated changes, since those relate to database column values and we don't have an instance.
             // and clear the pending changes set.
@@ -369,22 +369,22 @@ return {
 
                     // apply defaults
                     for ( elementPath in model.dataTableModel ) {
-						if ( model.dataTableModel.hasOwnProperty(elementPath) ) {
-							jsonType = model.dataTableModel[elementPath];
-							if ( jsonType['default'] !== undefined && jsonType['default'] !== null ) {
-								// otherwise, use the default for the session variable
-								databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, jsonType['default'], accumulatedChanges, true);
-							}
-						}
+                        if ( model.dataTableModel.hasOwnProperty(elementPath) ) {
+                            jsonType = model.dataTableModel[elementPath];
+                            if ( jsonType['default'] !== undefined && jsonType['default'] !== null ) {
+                                // otherwise, use the default for the session variable
+                                databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, jsonType['default'], accumulatedChanges, true);
+                            }
+                        }
                     }
                     // and now apply any changes from the instanceMetadataKeyValueMap
                     // NOTE: this will have been cleared at the top of the method if sameInstance is true.
                     for ( elementPath in instanceMetadataKeyValueMap ) {
-						if ( instanceMetadataKeyValueMap.hasOwnProperty(elementPath) ) {
-							jsonType = model.dataTableModel[elementPath];
-							value = databaseUtils.fromSerializationToElementType(jsonType, instanceMetadataKeyValueMap[elementPath], true);
-							databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, value, accumulatedChanges, true);
-						}
+                        if ( instanceMetadataKeyValueMap.hasOwnProperty(elementPath) ) {
+                            jsonType = model.dataTableModel[elementPath];
+                            value = databaseUtils.fromSerializationToElementType(jsonType, instanceMetadataKeyValueMap[elementPath], true);
+                            databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, value, accumulatedChanges, true);
+                        }
                     }
 
                     if ( $.isEmptyObject(accumulatedChanges)) {
@@ -406,15 +406,15 @@ return {
                     // and now apply any changes from the instanceMetadataKeyValueMap
                     // NOTE: this will have been cleared at the top of the method if sameInstance is true.
                     for ( elementPath in instanceMetadataKeyValueMap ) {
-						if ( instanceMetadataKeyValueMap.hasOwnProperty(elementPath) ) {
-							if ( instanceMetadataKeyValueMap[elementPath] === null ) {
-								value = null;
-							} else {
-								jsonType = model.dataTableModel[elementPath];
-								value = databaseUtils.fromSerializationToElementType(jsonType, instanceMetadataKeyValueMap[elementPath], true);
-							}
-							databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, value, accumulatedChanges, true);
-						}
+                        if ( instanceMetadataKeyValueMap.hasOwnProperty(elementPath) ) {
+                            if ( instanceMetadataKeyValueMap[elementPath] === null ) {
+                                value = null;
+                            } else {
+                                jsonType = model.dataTableModel[elementPath];
+                                value = databaseUtils.fromSerializationToElementType(jsonType, instanceMetadataKeyValueMap[elementPath], true);
+                            }
+                            databaseUtils.setModelDataValueDeferredChange( model, formId, instanceId, elementPath, value, accumulatedChanges, true);
+                        }
                     }
 
                     if ( $.isEmptyObject(accumulatedChanges)) {
@@ -426,8 +426,8 @@ return {
                 }
             },
             function(errorMsg) { 
-				ctxt.failure({message: errorMsg}); 
-			});
+                ctxt.failure({message: errorMsg}); 
+            });
     },
 
     ///////////////////////////////////////////////////
@@ -476,19 +476,19 @@ return {
                         savepoint_creator: reqData.getData(rowCntr, '_savepoint_creator'),
                         locale: reqData.getData(rowCntr, '_locale'),
                         form_id: reqData.getData(rowCntr, '_form_id'),
-						default_access: reqData.getData(rowCntr, '_default_access'),
-						row_owner: reqData.getData(rowCntr, '_row_owner'),
-						group_read_only: reqData.getData(rowCntr, '_group_read_only'),
-						group_modify: reqData.getData(rowCntr, '_group_modify'),
-						group_privileged: reqData.getData(rowCntr, '_group_privileged'),
+                        default_access: reqData.getData(rowCntr, '_default_access'),
+                        row_owner: reqData.getData(rowCntr, '_row_owner'),
+                        group_read_only: reqData.getData(rowCntr, '_group_read_only'),
+                        group_modify: reqData.getData(rowCntr, '_group_modify'),
+                        group_privileged: reqData.getData(rowCntr, '_group_privileged'),
                         effective_access: reqData.getData(rowCntr, '_effective_access')
                     });
                 }
                 ctxt.log('D','get_linked_instances.inside', dbTableName + " instanceList: " + instanceList.length);
                 ctxt.success(instanceList);
             }, function(errorMsg) { 
-				ctxt.failure({message: errorMsg}); 
-			});
+                ctxt.failure({message: errorMsg}); 
+            });
     },
 
     save_all_changes:function(ctxt, model, formId, instanceId, asComplete) {
@@ -514,8 +514,8 @@ return {
                     }
                 },
                 function(errorMsg) { 
-					that._process_odkData_error(ctxt, errorMsg);
-				});
+                    that._process_odkData_error(ctxt, errorMsg);
+                });
         } else {
             odkData.saveCheckpointAsIncomplete(model.table_id, simpleMap, instanceId,
                 function(reqData) {
@@ -527,8 +527,8 @@ return {
                     }
                 },
                 function(errorMsg) { 
-					that._process_odkData_error(ctxt, errorMsg);
-				});
+                    that._process_odkData_error(ctxt, errorMsg);
+                });
         }
     },
 
@@ -553,7 +553,7 @@ return {
                     ctxt.success();
                 },
                 function(errorMsg) {
-					that._process_odkData_error(ctxt, errorMsg);
+                    that._process_odkData_error(ctxt, errorMsg);
                 });
     },
 
@@ -573,8 +573,8 @@ return {
                                 }
                             },
                             function(errorMsg) {
-								that._process_odkData_error(ctxt, errorMsg);
-							});
+                                that._process_odkData_error(ctxt, errorMsg);
+                            });
 
     },
 
@@ -591,35 +591,35 @@ return {
                 }
             },
             function(errorMsg) { 
-				ctxt.failure({message: errorMsg}); 
-			});
+                ctxt.failure({message: errorMsg}); 
+            });
     },
 
-	_auth_error: "org.opendatakit.exception.ActionNotAuthorizedException:",
-	_impl_class_qualifier: " ODKDatabaseImplUtils:",
-	
-	_process_odkData_error: function(ctxt, errorMsg) {
-		var that = this;
-		
-		if ( errorMsg.startsWith(that._auth_error) ) {
-			// we cannot make the changes because of an Authorization violation. Clear them!
-			that.pendingChanges = {};
-		}
+    _auth_error: "org.opendatakit.exception.ActionNotAuthorizedException:",
+    _impl_class_qualifier: " ODKDatabaseImplUtils:",
+    
+    _process_odkData_error: function(ctxt, errorMsg) {
+        var that = this;
+        
+        if ( errorMsg.startsWith(that._auth_error) ) {
+            // we cannot make the changes because of an Authorization violation. Clear them!
+            that.pendingChanges = {};
+        }
 
-		var exception = null;
-		var idxColon = errorMsg.indexOf(':');
-		if ( idxColon !== -1 ) {
-			exception = errorMsg.substring(0,idxColon);
-			errorMsg = errorMsg.substring(idxColon+2);
-			var idxUtils = errorMsg.indexOf(that._impl_class_qualifier);
-			if ( idxUtils !== -1 ) {
-				errorMsg = errorMsg.substring(0, idxUtils) + errorMsg.substring(idxUtils + that._impl_class_qualifier.length);
-			}
-		}
-		
-		ctxt.failure({message: errorMsg, exception: exception, rolledBack: true});
-	},
-	
+        var exception = null;
+        var idxColon = errorMsg.indexOf(':');
+        if ( idxColon !== -1 ) {
+            exception = errorMsg.substring(0,idxColon);
+            errorMsg = errorMsg.substring(idxColon+2);
+            var idxUtils = errorMsg.indexOf(that._impl_class_qualifier);
+            if ( idxUtils !== -1 ) {
+                errorMsg = errorMsg.substring(0, idxUtils) + errorMsg.substring(idxUtils + that._impl_class_qualifier.length);
+            }
+        }
+        
+        ctxt.failure({message: errorMsg, exception: exception, rolledBack: true});
+    },
+    
     /**
      * Not expected to be called expect internally
      *
@@ -638,7 +638,7 @@ return {
                 }
             },
             function(errorMsg) {
-				that._process_odkData_error(ctxt, errorMsg);
+                that._process_odkData_error(ctxt, errorMsg);
             });
     },
 
@@ -658,10 +658,10 @@ return {
         var key;
         var jsonType;
         for ( key in accumulatedChanges ) {
-			if ( accumulatedChanges.hasOwnProperty(key) ) {
+            if ( accumulatedChanges.hasOwnProperty(key) ) {
               jsonType = dataTableModel[key];
               simpleMap[key] = databaseUtils.toOdkDataInterfaceFromElementType(jsonType, accumulatedChanges[key].value, true);
-			}
+            }
         }
         // metadata fields other than formId and creator are managed in the service layer.
         // TODO: should current user also be enforced here??
@@ -709,11 +709,11 @@ return {
             ctxt.success();
             return;
         }
-		if ( $.isEmptyObject(that.pendingChanges) ) {
-			ctxt.success();
-			return;
-		}
-		
+        if ( $.isEmptyObject(that.pendingChanges) ) {
+            ctxt.success();
+            return;
+        }
+        
         that._add_checkpoint($.extend({}, ctxt, {
                 failure:function(m) {
                     // a failure happened during writing -- reload state from db
@@ -744,15 +744,15 @@ return {
         var defn;
 
         for ( f in model.dataTableModel ) {
-		  if ( model.dataTableModel.hasOwnProperty(f) ) {
-		    defn = model.dataTableModel[f];
-			if (  defn.elementSet === 'instanceMetadata' &&
-			      ( (defn.elementPath === name) ||
-				   ((defn.elementPath === undefined || defn.elementPath === null) && (f === name)) ) ) {
-			  dbColumnName = f;
-			  break;
-			}
-		  }
+          if ( model.dataTableModel.hasOwnProperty(f) ) {
+            defn = model.dataTableModel[f];
+            if (  defn.elementSet === 'instanceMetadata' &&
+                  ( (defn.elementPath === name) ||
+                   ((defn.elementPath === undefined || defn.elementPath === null) && (f === name)) ) ) {
+              dbColumnName = f;
+              break;
+            }
+          }
         }
         if ( dbColumnName === undefined || dbColumnName === null ) {
           ctxt.log('E','setInstanceMetaData: Unrecognized instance metadata name: ' + name);
@@ -783,7 +783,7 @@ return {
             // overwrite the existing model with this one
             var model = opendatakit.getCurrentModel();
             model.formDef = tlo.formDef;
-			model.resultObject = tlo.resultObject;
+            model.resultObject = tlo.resultObject;
             model.dataTableModel = tlo.dataTableModel;
             model.metadata = tlo.metadata;
             model.instanceMetadata = tlo.instanceMetadata;

--- a/app/system/survey/js/odkSurveyStateManagement.js
+++ b/app/system/survey/js/odkSurveyStateManagement.js
@@ -285,14 +285,6 @@ window.odkSurveyStateManagement = window.odkSurveyStateManagement || {
 
         return null;
     },
-    frameworkHasLoaded: function(refId, outcome) {
-        if (this.enforceRefIdMatch && refId !== this._getRefId()) {
-            odkCommon.log("D","odkSurveyStateManagement: IGNORED: frameworkHasLoaded(" + refId + ", " + outcome + ")");
-            return;
-        }
-        odkCommon.log("E","odkSurveyStateManagement: DO: frameworkHasLoaded(" + refId + ", " + outcome + ")");
-        if ( this.showAlerts ) alert("notify container frameworkHasLoaded " + (outcome ? "SUCCESS" : "FAILURE"));
-    },
     saveAllChangesCompleted: function( refId, instanceId, asComplete ) {
         if (this.enforceRefIdMatch && refId !== this._getRefId()) {
             odkCommon.log("D","odkSurveyStateManagement: IGNORED: saveAllChangesCompleted(" + refId + ", " + instanceId + ", " + asComplete + ")");

--- a/app/system/survey/js/opendatakit.js
+++ b/app/system/survey/js/opendatakit.js
@@ -213,6 +213,15 @@ return {
     },
 
     getChoicesDefinition: function(choice_list_name) {
+        // the table properties retrieved from the Java layer should provide the definitive choice list. 
+        if ( this.mdl.resultObject !== null && this.mdl.resultObject !== undefined ) { 
+            var result = this.mdl.resultObject.getColumnChoicesList(choice_list_name); 
+            if ( result !== null && result !== undefined ) { 
+                return result; 
+            } 
+        } 
+        // but the list might not be available? In which case we use the one in the formDef. 
+        odkCommon.log('W', 'Using this.mdl.formDef.specification.choices instead of Table properties for choice definitions'); 
         return this.mdl.formDef.specification.choices[choice_list_name];
     },
 


### PR DESCRIPTION
This is the content of the JS zip updates to survey and tables. 

1. add metaDataRev to all odkDataIf APIs.  

2. add caching and retrieval of tableId's metaDataRev value and metadata to odkData object via _getTableMetadata(tableId), etc. These are internal routines. 

3. Upon receiving a result, if it contains metadata that can be cached (returned in metadata.cachedMetadata), expand this for use within the JS layer and place this into the odkData cache of this data.  

4. copy the cached metadata into the result object when we get one, if we can. 

5. add APIs to access choice list information from a result object.  

6. update mock odkDataIf (used within app-designer) to mimic the return structure and content of Java layer.

fix: remove 'orderedColumns' field from mock layer and database.js -- this is no longer returned (only dataTableModel is returned)
