### PR TITLE
Fix Grunt adbpush-default-app 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -490,12 +490,13 @@ var zipAllFiles = function( destZipFile, filesList, completionFn ) {
             // name, effectively pushing everything twice.  We also specify that we
             // want everything returned to be relative to 'app' by using 'cwd'.
             var dirs = grunt.file.expand(
-                { cwd: 'app' },
-                '.nomedia',
-                '*',
-                '!system',
-                '!data',
-                '!output');
+                {filter: 'isFile',
+                 cwd: 'app' },
+				'.nomedia',
+                '**',
+                '!system/**',
+				'!data/**',
+				'!output/**');
 
             // Now push these files to the phone.
             dirs.forEach(function(fileName) {


### PR DESCRIPTION
This reverts commit 7b9f60fa12ab8a06d88088190618f0f3cbb444c7.

As noted in the comments, 
https://github.com/opendatakit/app-designer/blob/2b7025b0d67a23d66f812eec79fca5da76266fb4/Gruntfile.js#L487-L490

Files must be pushed individually, otherwise they might end up in the wrong directory. 

7b9f60fa12ab8a06d88088190618f0f3cbb444c7 changed the task to push directories instead of files to improve performance. 

Closes https://github.com/opendatakit/opendatakit/issues/1367
Closes https://github.com/opendatakit/opendatakit/issues/1364