### PR TITLE
Fixes opendatakit/opendatakit#1410

### DIFF
--- a/app/config/assets/css/odk-survey.css
+++ b/app/config/assets/css/odk-survey.css
@@ -159,6 +159,10 @@ input[type="range"]::-webkit-slider-thumb:before {
 }
 .odk-options-btn {
     width:100%;
+
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 }
 .odk-header-back-btn {
     padding-left: 0;
@@ -172,7 +176,7 @@ input[type="range"]::-webkit-slider-thumb:before {
     padding-left: 15px;
     padding-right: 0;
 }
-.navbar-btn {
+.odk-navbar-btn {
     width:100%;
 }
 

--- a/app/config/tables/gridScreen/forms/gridScreen/comparison_screen.handlebars
+++ b/app/config/tables/gridScreen/forms/gridScreen/comparison_screen.handlebars
@@ -3,16 +3,16 @@
         <div class="row odk-header container">
             <div class="my-breakpoint {{#if hideNavigationButtonText}}my-breakpoint-no-nav-btn-text{{/if}}">
                 <div class="col-xs-6">
-                    <button type="button" class="odk-options-btn btn btn-default btn-lg" data-toggle="modal" data-target="#myModal" tabindex="0">
+                    <button type="button" class="odk-options-btn btn btn-default btn-lg odk-navbar-btn" data-toggle="modal" data-target="#myModal" tabindex="0">
                         <span>{{localizeText form_title}}</span>
                     </button>
                 </div>
                 <div class="col-xs-3 odk-header-back-btn">
-                    <a class="odk-prev-btn btn btn-default btn-lg navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
+                    <a class="odk-prev-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
                     {{#unless hideNavigationButtonText}}<span class="glyphicon glyphicon-chevron-left" style="float:left"></span> {{localizeText 'back_button_label'}}{{/unless}}</a> 
                 </div>
                 <div class="col-xs-3 odk-next-btn">   
-                    <a class="odk-next-btn btn btn-default btn-lg navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0">
+                    <a class="odk-next-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0">
                     {{#unless hideNavigationButtonText}}{{#if showAsContinueButton}}{{localizeText 'continue_button_label'}}{{else}}{{localizeText 'next_button_label'}}{{/if}} <span class="glyphicon glyphicon-chevron-right" style="float:right"></span>{{/unless}}</a>               
                 </div>
             </div>
@@ -143,14 +143,14 @@
     <div class="row odk-footer container">
         <div class="my-breakpoint {{#if hideNavigationButtonText}}my-breakpoint-no-nav-btn-text{{/if}}">
             <div class="col-xs-3 odk-footer-back-btn ">
-                <a class="odk-prev-btn btn btn-default btn-lg navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
+                <a class="odk-prev-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
                 {{#unless hideNavigationButtonText}}<span class="glyphicon glyphicon-chevron-left" style="float:left"></span> {{localizeText 'back_button_label'}}{{/unless}}</a> 
             </div>
             <div class="col-xs-6">
 
             </div>
             <div class="col-xs-3 odk-next-btn">   
-                <a class="odk-next-btn btn btn-default btn-lg navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0" >
+                <a class="odk-next-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0" >
                 {{#unless hideNavigationButtonText}}{{#if showAsContinueButton}}{{localizeText 'continue_button_label'}}{{else}}{{localizeText 'next_button_label'}}{{/if}} <span class="glyphicon glyphicon-chevron-right" style="float:right"></span>{{/unless}}</a>               
             </div>
         </div>

--- a/app/system/survey/templates/custom_screen.handlebars
+++ b/app/system/survey/templates/custom_screen.handlebars
@@ -3,16 +3,16 @@
         <div class="row odk-header container">
             <div class="my-breakpoint {{#if hideNavigationButtonText}}my-breakpoint-no-nav-btn-text{{/if}}">
                 <div class="col-xs-6">
-                    <button type="button" class="odk-options-btn btn btn-default btn-lg" data-toggle="modal" data-target="#myModal" tabindex="0">
+                    <button type="button" class="odk-options-btn btn btn-default btn-lg odk-navbar-btn" data-toggle="modal" data-target="#myModal" tabindex="0">
                         <span>{{localizeText form_title}}</span>
                     </button>
                 </div>
                 <div class="col-xs-3 odk-header-back-btn">
-                    <a class="odk-prev-btn btn btn-default btn-lg navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
+                    <a class="odk-prev-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
                     {{#unless hideNavigationButtonText}}<span class="glyphicon glyphicon-chevron-left" style="float:left"></span> {{localizeText 'back_button_label'}}{{/unless}}</a> 
                 </div>
                 <div class="col-xs-3 odk-next-btn">   
-                    <a class="odk-next-btn btn btn-default btn-lg navbar-btn  {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0">
+                    <a class="odk-next-btn btn btn-default btn-lg odk-navbar-btn  {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0">
                     {{#unless hideNavigationButtonText}}{{#if showAsContinueButton}}{{localizeText 'continue_button_label'}}{{else}}{{localizeText 'next_button_label'}}{{/if}} <span class="glyphicon glyphicon-chevron-right" style="float:right"></span>{{/unless}}</a>               
                 </div>
             </div>
@@ -48,14 +48,14 @@ to be displayed if "myPromptName" is not visible&lt;div&gt;
     <div class="row odk-footer container">
         <div class="my-breakpoint {{#if hideNavigationButtonText}}my-breakpoint-no-nav-btn-text{{/if}}">
             <div class="col-xs-3 odk-footer-back-btn ">
-                <a class="odk-prev-btn btn btn-default btn-lg navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
+                <a class="odk-prev-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
                 {{#unless hideNavigationButtonText}}<span class="glyphicon glyphicon-chevron-left" style="float:left"></span> {{localizeText 'back_button_label'}}{{/unless}}</a> 
             </div>
             <div class="col-xs-6">
 
             </div>
             <div class="col-xs-3 odk-next-btn">   
-                <a class="odk-next-btn btn btn-default btn-lg navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0">
+                <a class="odk-next-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0">
                 {{#unless hideNavigationButtonText}}{{#if showAsContinueButton}}{{localizeText 'continue_button_label'}}{{else}}{{localizeText 'next_button_label'}}{{/if}} <span class="glyphicon glyphicon-chevron-right" style="float:right"></span>{{/unless}}</a>               
             </div>
         </div>

--- a/app/system/survey/templates/navbar.handlebars
+++ b/app/system/survey/templates/navbar.handlebars
@@ -3,16 +3,16 @@
         <div class="row odk-header container">
             <div class="my-breakpoint {{#if hideNavigationButtonText}}my-breakpoint-no-nav-btn-text{{/if}}">
                 <div class="col-xs-6">
-                    <button type="button" class="odk-options-btn btn btn-default btn-lg" data-toggle="modal" data-target="#myModal" tabindex="0">
+                    <button type="button" class="odk-options-btn btn btn-default btn-lg odk-navbar-btn" data-toggle="modal" data-target="#myModal" tabindex="0">
                         <span>{{localizeText form_title}}</span>
                     </button>
                 </div>
                 <div class="col-xs-3 odk-header-back-btn">
-                    <a class="odk-prev-btn btn btn-default btn-lg navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
+                    <a class="odk-prev-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
                     {{#unless hideNavigationButtonText}}<span class="glyphicon glyphicon-chevron-left" style="float:left"></span> {{localizeText 'back_button_label'}}{{/unless}}</a> 
                 </div>
                 <div class="col-xs-3 odk-next-btn">   
-                    <a class="odk-next-btn btn btn-default btn-lg navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0">
+                    <a class="odk-next-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0">
                     {{#unless hideNavigationButtonText}}{{#if showAsContinueButton}}{{localizeText 'continue_button_label'}}{{else}}{{localizeText 'next_button_label'}}{{/if}} <span class="glyphicon glyphicon-chevron-right" style="float:right"></span>{{/unless}}</a>               
                 </div>
             </div>
@@ -25,14 +25,14 @@
     <div class="row odk-footer container">
         <div class="my-breakpoint {{#if hideNavigationButtonText}}my-breakpoint-no-nav-btn-text{{/if}}">
             <div class="col-xs-3 odk-footer-back-btn ">
-                <a class="odk-prev-btn btn btn-default btn-lg navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
+                <a class="odk-prev-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableBackNavigation}}disabled{{/unless}}" tabindex="0">
                 {{#unless hideNavigationButtonText}}<span class="glyphicon glyphicon-chevron-left" style="float:left"></span> {{localizeText 'back_button_label'}}{{/unless}}</a> 
             </div>
             <div class="col-xs-6">
 
             </div>
             <div class="col-xs-3 odk-next-btn">   
-                <a class="odk-next-btn btn btn-default btn-lg navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0" >
+                <a class="odk-next-btn btn btn-default btn-lg odk-navbar-btn {{#unless enableForwardNavigation}}disabled{{/unless}}" tabindex="0" >
                 {{#unless hideNavigationButtonText}}{{#if showAsContinueButton}}{{localizeText 'continue_button_label'}}{{else}}{{localizeText 'next_button_label'}}{{/if}} <span class="glyphicon glyphicon-chevron-right" style="float:right"></span>{{/unless}}</a>               
             </div>
         </div>


### PR DESCRIPTION
Fixes opendatakit/opendatakit#1410

Add CSS hint to form name button so that when the name doesn't fit in the box, ellipses are added. 

In addition, the class name navbar-btn is changed to odk-navbar-btn so that it doesn't collide with a Bootstrap class name. 

Note: 
PR for Survey to update the zips will be opened after this is merged. 