### PR TITLE
Allow the user to specify which port to run app-designer on, use “gru…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,6 +102,9 @@ module.exports = function (grunt) {
     // load all grunt tasks
     require('load-grunt-tasks')(grunt);
 
+    // passing in port as input
+    SERVER_PORT = grunt.option('port') || 8000;
+
     // We do not want the default behavior of serving only the app folder.
     // Instead we want to serve the base repo directory, as this will give us
     // access to the test dir as well. Further, if you don't have a homescreen

--- a/devEnv/js/devenv-util.js
+++ b/devEnv/js/devenv-util.js
@@ -112,7 +112,7 @@ exports.postFile = function(path, content, callback) {
     if (request.post !== undefined) {
         request.post(
             {
-                uri: exports.rootpath + '/' + path,
+                uri: '/' + path,
                 body: content
             },
             callback);
@@ -128,7 +128,7 @@ exports.postBase64File = function(path, content, callback) {
     if (request.post !== undefined) {
         request.post(
             {
-                uri: exports.rootpath + '/' + path,
+                uri: '/' + path,
                 body: content,
                 headers: { 
                     'Content-Type': 'application/octet-stream'


### PR DESCRIPTION
…nt —port=9000”