### PR TITLE
Fix display issue w/select_multiple

### DIFF
--- a/app/system/survey/js/prompts.js
+++ b/app/system/survey/js/prompts.js
@@ -1729,7 +1729,7 @@ promptTypes.input_type = promptTypes.base.extend({
     type: "input_type",
     templatePath: "templates/input_type.handlebars",
     inputAttributes: {
-        'placeholder':'not specified'
+        'placeholder':''
     },
     displayed: false,
     modified: false,

--- a/app/system/survey/js/prompts.js
+++ b/app/system/survey/js/prompts.js
@@ -1309,9 +1309,12 @@ promptTypes.select = promptTypes._linked_type.extend({
         var matchedChoice = null;
         var choiceList = [];
         var newChoice = null;
-
         if (savedValue === null || savedValue === undefined)
             return choiceList;
+
+        if (!Array.isArray(savedValue)) {
+			savedValue = savedValue.split(',');
+		}
 
         for (var i = 0; i < savedValue.length; i++)
         {


### PR DESCRIPTION
### This PR aims to fix an issue with select_multiple not displaying selected values

`parseSaveValue(savedValue)` does not work correctly, as it receives a 'savedValue' of type `string`, but treats it as an `array`, causing it to not display the selected items correctly (and also doing an unfortunate iteration on savedValue.length - which then of course is the string length of the concatenated selected items (!) and not the array length as the code expected).