### PR TITLE
Add CircleCI config for Playwright tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
 
       - run:
-          name: Install system dependencies  
+          name: Install system dependencies
           command: apt-get update && apt-get install -y curl
 
       - run:
@@ -48,7 +48,11 @@ jobs:
             ps aux | grep grunt || echo "No grunt processes found"
             
             # Check if grunt process exists but maybe on different port
-            netstat -tlnp | grep grunt || echo "No grunt-related ports found"
+            ss -tlnp | grep :8000 || echo "No process listening on port 8000"
+            ps aux | grep grunt || echo "No grunt processes found"
+            
+            # Check if grunt process exists but maybe on different port
+            ss -tlnp | grep grunt || echo "No grunt-related ports found"
             
             exit 1
       


### PR DESCRIPTION
#### Description:

Adds .circleci/config.yml to run Playwright tests in CI using the Playwright, start a Grunt server, wait for readiness, run tests, and store results as artifacts.